### PR TITLE
タワー全体のオブジェクトの制御を行うクラスを作成

### DIFF
--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -203,6 +203,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   towerObjectSpawner: {fileID: 4026947311019216309}
+  playerController: {fileID: 0}
+  spawnNum: 10
+  testActionText: {fileID: 1212625537215157468}
 --- !u!1 &3001194755703834647
 GameObject:
   m_ObjectHideFlags: 0
@@ -236,6 +239,7 @@ Transform:
   - {fileID: 23056774455636474}
   - {fileID: 1801718243418715878}
   - {fileID: 5694864741792544827}
+  - {fileID: 4887567231905125381}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -345,3 +349,181 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   maxParticleDespawnTime: 300
+--- !u!1 &5067051283888320131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4887567231905125381}
+  - component: {fileID: 5282942193809151472}
+  - component: {fileID: 4384305422101147247}
+  - component: {fileID: 2920781010419693422}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4887567231905125381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067051283888320131}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1484073462911453129}
+  m_Father: {fileID: 3001194755703834644}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &5282942193809151472
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067051283888320131}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4384305422101147247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067051283888320131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &2920781010419693422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067051283888320131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &6707066825343704934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1484073462911453129}
+  - component: {fileID: 7371597609938227064}
+  - component: {fileID: 1212625537215157468}
+  m_Layer: 5
+  m_Name: ActionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1484073462911453129
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6707066825343704934}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4887567231905125381}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -141, y: 822}
+  m_SizeDelta: {x: 500, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7371597609938227064
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6707066825343704934}
+  m_CullTransparentMesh: 0
+--- !u!114 &1212625537215157468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6707066825343704934}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 70
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 70
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: ActionText

--- a/Assets/Scripts/TowerDatas/TowerObjectController.cs
+++ b/Assets/Scripts/TowerDatas/TowerObjectController.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// タワーオブジェクト全体の制御を行う
+/// </summary>
+/// NOTE : テスト用のコードも入っており汚いです。今後綺麗にしていきます。
+public class TowerObjectController : MonoBehaviour
+{
+    // オブジェクトのスポナークラス
+    [SerializeField]
+    TowerObjectSpawner towerObjectSpawner = default;
+
+    // 積みあがったオブジェクト
+    Queue<(Transform, string)> stackedObjects = new Queue<(Transform, string)>();
+
+    [SerializeField]
+    PlayerController playerController = default;
+
+    // スポーンさせる数
+    [SerializeField] int spawnNum = 0;
+
+    // プレイヤーのアクションを表すテキスト
+    // NOTE : 実機でもプレイヤーがどのアクションを行ったかが分かるようにするためのテキストです。
+    //        アクションごとのイベントが完成したら消します。
+    [SerializeField] Text testActionText = default;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // スポーンの制御を行う
+        ControlSpawn();
+
+        // ディスポーンの処理を行う
+        ControlDespawn();
+    }
+
+    /// <summary>
+    /// スポーンの制御を行う
+    /// </summary>
+    void ControlSpawn()
+    {
+        // 現在のオブジェクトの数がスポーンさせる数を下回ったら、新たにスポーンさせる
+        if (stackedObjects.Count < spawnNum)
+        {
+            // スポーンしたオブジェクト
+            IEnumerable<(Transform, string)> spawnedObjects;
+
+            // オブジェクトをスポーンする
+            spawnedObjects = towerObjectSpawner.Spawn(spawnNum);
+
+            foreach ((Transform, string) spawnedObject in spawnedObjects)
+            {
+                stackedObjects.Enqueue(spawnedObject);
+            }
+        }
+    }
+
+    /// <summary>
+    /// ディスポーンの処理を行う
+    /// </summary>
+    void ControlDespawn()
+    {
+        // プレイヤーがパンチしたら
+        if (playerController.IsPunch)
+        {
+            // タワーの下のオブジェクトを取得
+            (Transform, string) underObject = stackedObjects.Dequeue();
+            // パンチされたオブジェクトを消す
+            towerObjectSpawner.Despawn(underObject.Item2, underObject.Item1);
+
+            // モチにパンチしたら
+            if (underObject.Item2 == TagName.Mochi)
+            {
+                // テスト用テキスト表示
+                testActionText.text = "モチにパンチ！";
+            }
+            // ウサギにパンチしたら
+            else
+            {
+                // テスト用テキスト表示
+                testActionText.text = "ウサギにパンチ！";
+            }
+        }
+        else if (playerController.IsRescue)
+        {
+            // タワーの下のオブジェクトを取得
+            (Transform, string) underObject = stackedObjects.Dequeue();
+            // パンチされたオブジェクトを消す
+            towerObjectSpawner.Despawn(underObject.Item2, underObject.Item1);
+
+            // モチにパンチしたら
+            if (underObject.Item2 == TagName.Mochi)
+            {
+                // テスト用テキスト表示
+                testActionText.text = "モチを助けた？";
+            }
+            // ウサギにパンチしたら
+            else
+            {
+                // テスト用テキスト表示
+                testActionText.text = "ウサギを助けた！";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TowerDatas/TowerObjectController.cs.meta
+++ b/Assets/Scripts/TowerDatas/TowerObjectController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9e8996281e47a048850aca27d4c773c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
タワーの状態を見て、スポーンや削除の処理を制御するクラスを作成した。
プレイヤーがオブジェクトに対して、どのアクションを行ったかが分かるように、テスト用のテキストを追加しているためコードが少し汚いです。
今後、調整していきます。

前回のプルリク「タワーオブジェクトのスポーンクラスを作成」を先に確認をお願いします。
それがマージされたら、このプルリクのマージ先をmasterに変更します。

【確認ファイル】
TowerObjectController.cs