### PR TITLE
タイムアップ時のフィニッシュ技関連の処理の修正

### DIFF
--- a/Assets/MyGameAssets/Animation/Player/Player.controller
+++ b/Assets/MyGameAssets/Animation/Player/Player.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-7631396584780799654
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Result
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.24515873
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-6006058947950517265
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -13,6 +38,28 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 292803045262181620}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-5868584781652147297
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -111,7 +158,8 @@ AnimatorState:
   m_Name: LowScoreCatch
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 6545846403850748785}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -147,6 +195,50 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.78571427
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-2041793652336057936
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.90625
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-1218541560416437199
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9056604
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -238,7 +330,8 @@ AnimatorState:
   m_Name: HighScoreResult
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 6046711822603603181}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -440,7 +533,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.20443338
   m_TransitionOffset: 0
   m_ExitTime: 0.74999994
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -695,7 +788,8 @@ AnimatorState:
   m_Name: LowScoreResult
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -7631396584780799654}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -711,6 +805,103 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &2627778881031048205
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5795632666467760964
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Main
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.90625
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &6046711822603603181
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Result
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.24065131
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &6545846403850748785
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Main
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102129973199918830}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9056604
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &6816613290359893537
 AnimatorState:
   serializedVersion: 5
@@ -721,7 +912,8 @@ AnimatorState:
   m_Name: HighScoreCatch
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 5795632666467760964}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -757,7 +949,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.78571427
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/MyGameAssets/Animation/Player/Rescue.anim
+++ b/Assets/MyGameAssets/Animation/Player/Rescue.anim
@@ -231,7 +231,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/MyGameAssets/Animation/Player/SpecialArts.anim
+++ b/Assets/MyGameAssets/Animation/Player/SpecialArts.anim
@@ -941,7 +941,7 @@ AnimationClip:
   m_HasGenericRootTransform: 1
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 1.15
+  - time: 1.1333333
     functionName: AnimStart
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/MyGameAssets/Scenes/stage1.unity
+++ b/Assets/MyGameAssets/Scenes/stage1.unity
@@ -706,7 +706,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timer: {fileID: 1172636030}
   startTime: 5
-  gameTime: 20
+  gameTime: 5
   plusSeconds: 5
 --- !u!114 &1172636030
 MonoBehaviour:
@@ -5816,7 +5816,6 @@ GameObject:
   - component: {fileID: 1647739455}
   - component: {fileID: 1647739457}
   - component: {fileID: 1647739456}
-  - component: {fileID: 1647739458}
   m_Layer: 5
   m_Name: MochiCount
   m_TagString: Untagged
@@ -5963,18 +5962,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1647739454}
   m_CullTransparentMesh: 0
---- !u!114 &1647739458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647739454}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7495dc32652c542118675487634da115, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1750253934
 GameObject:
   m_ObjectHideFlags: 0
@@ -6027,7 +6014,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   countText: {fileID: 1647739456}
-  counter: {fileID: 1647739458}
+  counter: {fileID: 0}
 --- !u!114 &1750253937
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MyGameAssets/Script/Player/MainPlayerAnimator.cs
+++ b/Assets/MyGameAssets/Script/Player/MainPlayerAnimator.cs
@@ -31,7 +31,7 @@ public class MainPlayerAnimator : SingletonMonoBehaviour<MainPlayerAnimator>
     /// </summary>
     void OnEnable()
     {
-        // 開始時にリザルトアニメーション開始
+        // 開始時にメインの待機モーションへ移動させる
         playerAnim.SetTrigger("Main");
     }
 
@@ -51,11 +51,15 @@ public class MainPlayerAnimator : SingletonMonoBehaviour<MainPlayerAnimator>
             case (int)AnimKind.OrangeCatch:
                 if (GameDataManager.Inst.PlayData.LastScore >= ScoreManager.GoodScore)
                 {
-                    playerAnim.SetTrigger("LowScore"); break;
+                    playerAnim.SetTrigger("LowScore");
                 }
                 {
-                    playerAnim.SetTrigger("HighScore"); break;
+                    playerAnim.SetTrigger("HighScore"); 
                 }
+
+                // NOTE:初回起動処理時はもともと待機モーションに入っており、
+                //      トリガーが残ってしまっているのでここでリセットを挟んでいます。
+                playerAnim.ResetTrigger("Main"); break;
         }
     }
 

--- a/Assets/MyGameAssets/Script/Player/PlayerController.cs
+++ b/Assets/MyGameAssets/Script/Player/PlayerController.cs
@@ -18,9 +18,19 @@ public class PlayerController : MonoBehaviour
     public bool isSpecialArts = false;                              // 大技フラグ
     public bool IsWait { get; private set; } = true;                // 待機中フラグ
 
-    public bool IsTimeup { get; private set; } = false;             // タイムアップフラグ
-
     int punchSide = (int)MainAnim.RightPunch;                       // パンチの種類
+
+    /// <summary>
+    /// 起動処理
+    /// </summary>
+    void OnEnable()
+    {
+        // フラグリセット
+        isPunch = false;
+        isRescue = false;
+        isSpecialArts = false;
+        IsWait = true;
+    }
 
     /// <summary>
     /// 更新処理
@@ -28,7 +38,7 @@ public class PlayerController : MonoBehaviour
     void Update()
     {
         // タイムアップになったら
-        if (Timer.Inst.IsTimeup)
+        if (Timer.Inst.IsTimeup && !isSpecialArts)
         {
             // 大技開始
             SpecialArts();

--- a/Assets/MyGameAssets/Script/Player/ResultPlayerAnimator.cs
+++ b/Assets/MyGameAssets/Script/Player/ResultPlayerAnimator.cs
@@ -25,7 +25,7 @@ public class ResultPlayerAnimator : SingletonMonoBehaviour<ResultPlayerAnimator>
     /// </summary>
     void OnEnable()
     {
-        // リザルトの待機開始
+        // 開始時にリザルトの待機モーションへ移動させる
         playerAnim.SetTrigger("Result");
     }
 

--- a/Assets/MyGameAssets/Script/Player/TitlePlayerAnimator.cs
+++ b/Assets/MyGameAssets/Script/Player/TitlePlayerAnimator.cs
@@ -22,7 +22,7 @@ public class TitlePlayerAnimator : SingletonMonoBehaviour<TitlePlayerAnimator>
     /// </summary>
     void OnEnable()
     {
-        // 開始時にタイトルアニメーション開始
+        // 開始時にタイトルの待機モーションへ移動させる
         playerAnim.SetTrigger("Title");
     }
 }

--- a/Assets/MyGameAssets/Script/ScoreManager.cs
+++ b/Assets/MyGameAssets/Script/ScoreManager.cs
@@ -34,9 +34,6 @@ public class ScoreManager : MonoBehaviour
     /// </summary>
     void OnEnable()
     {
-        // カウンターリセット
-        counter.Reset();
-
         // カウンターがなければ初期化
         if (counter == null)
         {
@@ -46,6 +43,9 @@ public class ScoreManager : MonoBehaviour
         // カウンターがあればカウントアップ開始前処理
         else
         {
+            // カウンターリセット
+            counter.Reset();
+
             // データから最終スコアを持ってくる
             getNum = GameDataManager.Inst.PlayData.LastScore;
 


### PR DESCRIPTION
タイムアップ時のフィニッシュ技がうまくいってなかったので修正しました。

MainPlayerAnimator.cs -> 2回目以降のトリガーリセットが1回目にも働いていたため修正
PlayerController.cs -> 起動時のフラグのリセットを追加、フィニッシュ技に移行する条件を修正
ScoreManager.cs -> カウンターのリセットの位置を修正