### PR TITLE
物理演算を使わないオブジェクトの落下処理を作成

### DIFF
--- a/Assets/Animations/Rabbit.controller
+++ b/Assets/Animations/Rabbit.controller
@@ -10,8 +10,7 @@ AnimatorState:
   m_Name: Stay
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -2452387255200206612}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -27,56 +26,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-3602173031559461028
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: RescueEnd
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -4688248008305281387}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 7.007972e-10
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &-2452387255200206612
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: RabbitRescue
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2009551628518392667}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -87,12 +36,6 @@ AnimatorController:
   serializedVersion: 5
   m_AnimatorParameters:
   - m_Name: RabbitRescue
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
-  - m_Name: RescueEnd
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -135,7 +78,7 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: -4688248008305281387}
+  m_DefaultState: {fileID: 2009551628518392667}
 --- !u!1102 &2009551628518392667
 AnimatorState:
   serializedVersion: 5
@@ -146,8 +89,7 @@ AnimatorState:
   m_Name: RabbitRescue
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -3602173031559461028}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Animations/RabbitRescue.anim
+++ b/Assets/Animations/RabbitRescue.anim
@@ -348,4 +348,11 @@ AnimationClip:
     script: {fileID: 0}
   m_HasGenericRootTransform: 1
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.98333335
+    functionName: OnControlFinished
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Prefabs/TowerObjectPrefabs/Mochi/MochiBase.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/Mochi/MochiBase.prefab
@@ -9,8 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2627852583044439303}
-  - component: {fileID: 8560863643188601127}
-  - component: {fileID: 7589670859040133996}
   - component: {fileID: 7206425726733323822}
   m_Layer: 0
   m_Name: MochiBase
@@ -33,35 +31,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &8560863643188601127
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490598115399705709}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 122
-  m_CollisionDetection: 0
---- !u!65 &7589670859040133996
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1490598115399705709}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &7206425726733323822
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -74,3 +43,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c844a9cd4830c146a58176a6fc53676, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  towerObjectSpawner: {fileID: 0}

--- a/Assets/Prefabs/TowerObjectPrefabs/Rabbit(Provisional)/RabbitBase.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/Rabbit(Provisional)/RabbitBase.prefab
@@ -9,8 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4100915124837455027}
-  - component: {fileID: 5828202417101325933}
-  - component: {fileID: 1742319943750739078}
   - component: {fileID: 8917716974617923675}
   - component: {fileID: 2056084347945563379}
   m_Layer: 0
@@ -34,35 +32,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &5828202417101325933
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7790459234046220267}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 122
-  m_CollisionDetection: 0
---- !u!65 &1742319943750739078
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7790459234046220267}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!95 &8917716974617923675
 Animator:
   serializedVersion: 3
@@ -76,7 +45,7 @@ Animator:
   m_Controller: {fileID: 0}
   m_CullingMode: 0
   m_UpdateMode: 0
-  m_ApplyRootMotion: 0
+  m_ApplyRootMotion: 1
   m_LinearVelocityBlending: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
@@ -94,4 +63,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aed8ac5e8ffd5d244a7215e9e4fb9ff3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  towerObjectSpawner: {fileID: 0}
   animator: {fileID: 8917716974617923675}

--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -638,6 +638,7 @@ GameObject:
   - component: {fileID: 7076311089230414547}
   - component: {fileID: 532754641122396853}
   - component: {fileID: 6371371037647465665}
+  - component: {fileID: 6687094425664445749}
   m_Layer: 0
   m_Name: TowerObject
   m_TagString: Untagged
@@ -722,6 +723,7 @@ MonoBehaviour:
   stackedObjectParent: {fileID: 1212671296861333797}
   mochiSpawnPool: {fileID: 2700076526512641449}
   rabbitSpawnPool: {fileID: 7024668247501201793}
+  groundSurfacePos: {x: 0, y: 0, z: 0}
   spawnHeightInterval: 5
 --- !u!114 &7076311089230414547
 MonoBehaviour:
@@ -768,6 +770,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mochiSpawnPool: {fileID: 23056774455636474}
   rabbitSpawnPool: {fileID: 1801718243418715878}
+--- !u!114 &6687094425664445749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3001194755703834647}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f4ea9be9e2a98f419e5e2110e54d548, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  towerObjectSpawner: {fileID: 1897852783884773167}
+  stackedObjectParent: {fileID: 1212671296861333797}
+  fallingLerpRate: 0.5
 --- !u!1 &3654277507259388085
 GameObject:
   m_ObjectHideFlags: 0
@@ -819,7 +836,7 @@ MonoBehaviour:
   logMessages: 0
   _perPrefabPoolOptions:
   - prefab: {fileID: 5675081278319782057}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -833,7 +850,7 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   - prefab: {fileID: 8014939569875803388}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -847,7 +864,7 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   - prefab: {fileID: 7192484000970764377}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -861,7 +878,7 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   - prefab: {fileID: 2673264453933576297}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -875,7 +892,7 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   - prefab: {fileID: 1456942064901991626}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -889,7 +906,7 @@ MonoBehaviour:
     _logMessages: 0
     spawnPool: {fileID: 0}
   - prefab: {fileID: 7275601892411603552}
-    preloadAmount: 10
+    preloadAmount: 20
     preloadTime: 0
     preloadFrames: 2
     preloadDelay: 0
@@ -1149,6 +1166,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &2673264453933576297 stripped
@@ -1249,6 +1271,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &4124579709173137630 stripped
@@ -1349,6 +1381,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &2311010038224224381 stripped
@@ -1449,6 +1491,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &1456942064901991626 stripped
@@ -1549,7 +1596,29 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
+    m_RemovedComponents:
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 1742319943750739078, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
+    - {fileID: 5828202417101325933, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &320239592990511528 stripped
 Transform:
@@ -1649,6 +1718,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &7275601892411603552 stripped
@@ -1749,6 +1823,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &7192484000970764377 stripped
@@ -1849,7 +1928,24 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    m_RemovedComponents:
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 7589670859040133996, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &8014939569875803388 stripped
 Transform:
@@ -1949,6 +2045,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &6644159777956555531 stripped
@@ -2049,6 +2155,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &6814378817764759076 stripped
@@ -2149,7 +2265,13 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 7206425726733323822, guid: 36e8901f89c9c214197842b8cb188ee5,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    m_RemovedComponents:
+    - {fileID: 8560863643188601127, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 36e8901f89c9c214197842b8cb188ee5, type: 3}
 --- !u!4 &5675081278319782057 stripped
 Transform:
@@ -2249,6 +2371,16 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 2056084347945563379, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: towerObjectSpawner
+      value: 
+      objectReference: {fileID: 1897852783884773167}
+    - target: {fileID: 8917716974617923675, guid: 5fe92344e1e9d2b49b10809b72b57956,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 41fbc0f28d2d68949b323f17f52226da, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fe92344e1e9d2b49b10809b72b57956, type: 3}
 --- !u!4 &5481728049189388093 stripped

--- a/Assets/Scenes/Test_mitsumaru.unity
+++ b/Assets/Scenes/Test_mitsumaru.unity
@@ -323,7 +323,7 @@ PrefabInstance:
     - target: {fileID: 3001194755703834644, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 83.2
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3001194755703834644, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
@@ -370,35 +370,35 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 2242710007955976163, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[0].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 2142290299034309324, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[1].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 1096761049339558869, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[2].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 5141634085333177664, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[3].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 8797231736005624886, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[4].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2700076526512641449, guid: 34e60736b952eee4dba2263ecaaa2597,
+    - target: {fileID: 7149785060958504085, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
-      propertyPath: _perPrefabPoolOptions.Array.data[5].preloadAmount
-      value: 20
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34e60736b952eee4dba2263ecaaa2597, type: 3}

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// タワーオブジェクトの落下制御を行う
+/// </summary>
+public class TowerObjectFallController : MonoBehaviour
+{
+    // タワーオブジェクトのスポーンクラス
+    [SerializeField]
+    TowerObjectSpawner towerObjectSpawner = default;
+
+    // 積みあがっているオブジェクトの親
+    [SerializeField]
+    Transform stackedObjectParent = default;
+
+    // 落下時のLerpの割合
+    [SerializeField]
+    float fallingLerpRate = 0;
+
+    // 前フレームのオブジェクトの数
+    int prevStackedObjectNum = 0;
+
+    // 落下距離
+    float fallDistance = 0;
+    // 落下終了位置
+    Vector3 fallEndPosition = Vector3.zero;
+    // 落下中かどうか
+    bool isFalling = false;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // 前フレームのオブジェクト数と比較して、タワーオブジェクトの数が変動したかチェック
+        if (stackedObjectParent.childCount != prevStackedObjectNum)
+        {
+            // オブジェクトのスポーン間隔の幅を落下移動距離として取得
+            fallDistance = towerObjectSpawner.SpawnHeightInterval;
+
+            // 親オブジェクトの移動先の位置を算出
+            fallEndPosition = new Vector3(stackedObjectParent.position.x,
+                                          stackedObjectParent.position.y - fallDistance,
+                                          stackedObjectParent.position.z);
+
+            // 落下フラグをオンにする
+            isFalling = true;
+        }
+
+        // フラグがオンであれば落下処理を行う
+        if (isFalling) { Falling(); }
+
+        // 前フレームのオブジェクト数として登録
+        prevStackedObjectNum = stackedObjectParent.childCount;
+    }
+
+    /// <summary>
+    /// 落下処理を行う
+    /// </summary>
+    void Falling()
+    {
+        // Lerpを利用してオブジェクトの落下移動を行う
+        stackedObjectParent.position = Vector3.Lerp(stackedObjectParent.position, fallEndPosition, fallingLerpRate);
+
+        // 現在の位置と終了位置との距離を算出
+        float currentPosToEndPosDist = Vector3.Magnitude(fallEndPosition - stackedObjectParent.position);
+
+        // Lerpの移動量が0.01以下になったら落下終了とみなす
+        if (currentPosToEndPosDist <= 0.01f)
+        {
+            isFalling = false;
+        }
+    }
+}

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs.meta
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f4ea9be9e2a98f419e5e2110e54d548
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -29,9 +29,14 @@ public class TowerObjectSpawner : MonoBehaviour
     [SerializeField]
     SpawnPool rabbitSpawnPool = default;
 
+    // オブジェクトの基準の位置
+    [SerializeField]
+    Vector3 baseSpawnPosition = Vector3.zero;
+
     // スポーン時のオブジェクト間の高さの間隔
     [SerializeField]
     float spawnHeightInterval = 0;
+    public float SpawnHeightInterval { get { return spawnHeightInterval; } }
 
     // 前回スポーンしたオブジェクトの種類
     string prevSpawnObjectType = null;
@@ -46,6 +51,11 @@ public class TowerObjectSpawner : MonoBehaviour
     {
         // 現在のモチのスキンを取得する
         mochiSkinType = GameDataManager.Inst.SettingData.UseSkin;
+
+        // スポーンの基準位置から最初のオブジェクトのスポーン位置を決定する（スポーン高さ = 地面の高さ * 1.5f）
+        transform.position = new Vector3(baseSpawnPosition.x,
+                                         baseSpawnPosition.y + spawnHeightInterval * 1.5f,
+                                         baseSpawnPosition.z);
     }
 
     /// <summary>
@@ -57,11 +67,14 @@ public class TowerObjectSpawner : MonoBehaviour
         // スポーンしたオブジェクト
         Transform spawnedObject;
 
+        // 基準のスポーン位置を取得
+        Vector3 baseSpawnPos = GetBaseSpawnPos();
+
         // 指定の数だけ繰り返し抽選を行い、スポーンしていく
         for (int spawnCount = 0; spawnCount < spawnNum;)
         {
             // スポーン位置の計算
-            Vector3 spawnPos = new Vector3(transform.position.x, transform.position.y + spawnHeightInterval * spawnCount, transform.position.z);
+            Vector3 spawnPos = new Vector3(baseSpawnPos.x, baseSpawnPos.y + spawnHeightInterval * spawnCount, baseSpawnPos.z);
 
             // モチかウサギかの抽選を行う
             string towerObjectType = objectTypeLotteryMachine.SpawnLotteryMochiAndRabbit();
@@ -125,6 +138,24 @@ public class TowerObjectSpawner : MonoBehaviour
         {
             Debug.LogError("ObjectType : " + spawnedObject.tag + " not found.");
         }
+    }
+
+    /// <summary>
+    /// 基準のスポーン位置を取得
+    /// </summary>
+    /// <returns></returns>
+    Vector3 GetBaseSpawnPos()
+    {
+        // タワーのオブジェクトが存在していなければ、最初のオブジェクトのスポーン位置を返す
+        if (stackedObjectParent.childCount <= 0)
+        {
+            return transform.position;
+        }
+
+        // タワーの一番上のオブジェクトを取得
+        Transform topObject = stackedObjectParent.GetChild(stackedObjectParent.childCount - 1);
+        // 一番上のオブジェクトのひとつ上の位置を基準のスポーン位置にする
+        return new Vector3(topObject.position.x, topObject.position.y + spawnHeightInterval, topObject.position.z);
     }
 
     /// <summary>

--- a/Assets/Scripts/TowerDatas/Mochi/MochiController.cs
+++ b/Assets/Scripts/TowerDatas/Mochi/MochiController.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 /// </summary>
 public class MochiController : ObjectControllerBase
 {
+    // オブジェクトのスポーンクラス
+    [SerializeField]
+    TowerObjectSpawner towerObjectSpawner = default;
+
     // TODO : 以下の関数にそれぞれのアクションに対応したオブジェクトの処理を実装する
 
     /// <summary>
@@ -30,5 +34,14 @@ public class MochiController : ObjectControllerBase
     public override void OnPlayerSpecialArts()
     {
 
+    }
+
+    /// <summary>
+    /// オブジェクトのアクションが終了したときに呼ぶコールバック
+    /// </summary>
+    public void OnControlFinished()
+    {
+        // オブジェクト自信をデスポーンする
+        towerObjectSpawner.Despawn(this.transform);
     }
 }

--- a/Assets/Scripts/TowerDatas/Rabbit/RabbitController.cs
+++ b/Assets/Scripts/TowerDatas/Rabbit/RabbitController.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 /// </summary>
 public class RabbitController : ObjectControllerBase
 {
+    // オブジェクトのスポーンクラス
+    [SerializeField]
+    TowerObjectSpawner towerObjectSpawner = default;
+
     // アニメーターコンポーネント
     [SerializeField]
     Animator animator = default;
@@ -34,5 +38,16 @@ public class RabbitController : ObjectControllerBase
     public override void OnPlayerSpecialArts()
     {
 
+    }
+
+    /// <summary>
+    /// オブジェクトのアクションが終了したときに呼ぶコールバック
+    /// </summary>
+    public void OnControlFinished()
+    {
+        // オブジェクト自信をデスポーンする
+        towerObjectSpawner.Despawn(this.transform);
+        // アニメーションを待機に変更
+        animator.Play("Stay");
     }
 }


### PR DESCRIPTION
Unityの物理演算は使わず、Lerpを使用してオブジェクトの落下処理を行うように変更した。
オブジェクトからRigidbodyとColliderを削除した。

前回のプルリク「タワー関連の不具合箇所を修正」を先に確認をお願いします。
それがマージされたらこちらのプルリクのマージ先をmasterに変更します。

【確認ファイル】
TowerObjectFallController.cs
TowerObjectSpawner.cs