### PR TITLE
プレイヤーからのアクションを受けた際のオブジェクトの処理を仮実装

### DIFF
--- a/Assets/Animations/Rabbit.controller
+++ b/Assets/Animations/Rabbit.controller
@@ -10,7 +10,9 @@ AnimatorState:
   m_Name: Stay
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 8270740425724485319}
+  - {fileID: 762890054092333000}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -35,7 +37,13 @@ AnimatorController:
   m_Name: Rabbit
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: RabbitRescue
+  - m_Name: RabbitRescued
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: RabbitFling
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -69,6 +77,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -4688248008305281387}
     m_Position: {x: 260, y: 110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8398907768686219326}
+    m_Position: {x: 510, y: 110, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -78,7 +89,32 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 2009551628518392667}
+  m_DefaultState: {fileID: -4688248008305281387}
+--- !u!1101 &762890054092333000
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: RabbitFling
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8398907768686219326}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.0000000017085918
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &2009551628518392667
 AnimatorState:
   serializedVersion: 5
@@ -100,6 +136,57 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: b93a4c4ea5c9e784d9ef99102040db0b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &8270740425724485319
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: RabbitRescued
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2009551628518392667}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &8398907768686219326
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: RabbitFlying
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 96180ef18cea1e349a13bbf6148ee501, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Assets/Animations/RabbitFlying.anim
+++ b/Assets/Animations/RabbitFlying.anim
@@ -1,0 +1,176 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: RabbitFlying
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: -2.6806946, y: 21.657417, z: 5.230036}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 1
+        value: {x: 10, y: 21.657417, z: 5.230036}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -2.6806946
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 10
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 21.657417
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 21.657417
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 5.230036
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1
+        value: 5.230036
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 1
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 0.98333335
+    functionName: OnControlFinished
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/RabbitFlying.anim.meta
+++ b/Assets/Animations/RabbitFlying.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96180ef18cea1e349a13bbf6148ee501
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -723,7 +723,7 @@ MonoBehaviour:
   stackedObjectParent: {fileID: 1212671296861333797}
   mochiSpawnPool: {fileID: 2700076526512641449}
   rabbitSpawnPool: {fileID: 7024668247501201793}
-  groundSurfacePos: {x: 0, y: 0, z: 0}
+  baseSpawnPosition: {x: 0, y: 0, z: 0}
   spawnHeightInterval: 5
 --- !u!114 &7076311089230414547
 MonoBehaviour:
@@ -784,7 +784,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   towerObjectSpawner: {fileID: 1897852783884773167}
   stackedObjectParent: {fileID: 1212671296861333797}
-  fallingLerpRate: 0.5
+  fallingLerpRate: 0.4
 --- !u!1 &3654277507259388085
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Test_mitsumaru.unity
+++ b/Assets/Scenes/Test_mitsumaru.unity
@@ -370,35 +370,40 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5802217174181155568, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2242710007955976163, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2142290299034309324, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1096761049339558869, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5141634085333177664, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8797231736005624886, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7149785060958504085, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34e60736b952eee4dba2263ecaaa2597, type: 3}

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectActionCaller.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectActionCaller.cs
@@ -56,13 +56,13 @@ public class TowerObjectActionCaller : MonoBehaviour
         else if (playerController.GetIsRescue())
         {
             // 救出されたときのコールバック
-            objectController.OnPlayerPunched();
+            objectController.OnPlayerRescued();
         }
         // プレイヤーから最後の大技を受けたとき
         else if (playerController.GetIsSpecialArts())
         {
             // 大技を受けたときのコールバック
-            objectController.OnPlayerPunched();
+            objectController.OnPlayerSpecialArts();
         }
     }
 }

--- a/Assets/Scripts/TowerDatas/Mochi/MochiController.cs
+++ b/Assets/Scripts/TowerDatas/Mochi/MochiController.cs
@@ -18,6 +18,8 @@ public class MochiController : ObjectControllerBase
     /// </summary>
     public override void OnPlayerPunched()
     {
+        // モチの終了処理
+        OnControlFinished();
     }
 
     /// <summary>
@@ -25,7 +27,8 @@ public class MochiController : ObjectControllerBase
     /// </summary>
     public override void OnPlayerRescued()
     {
-
+        // モチの終了処理
+        OnControlFinished();
     }
 
     /// <summary>

--- a/Assets/Scripts/TowerDatas/Rabbit/RabbitController.cs
+++ b/Assets/Scripts/TowerDatas/Rabbit/RabbitController.cs
@@ -22,6 +22,8 @@ public class RabbitController : ObjectControllerBase
     /// </summary>
     public override void OnPlayerPunched()
     {
+        // ウサギが吹っ飛ぶアニメーションを再生
+        animator.SetTrigger("RabbitFling");
     }
 
     /// <summary>
@@ -29,7 +31,8 @@ public class RabbitController : ObjectControllerBase
     /// </summary>
     public override void OnPlayerRescued()
     {
-
+        // ウサギが救出されるアニメーションを再生
+        animator.SetTrigger("RabbitRescued");
     }
 
     /// <summary>


### PR DESCRIPTION
プレイヤーからのアクションに応じたタワーオブジェクトのアクションを以下の通りに仮実装した。
・モチを破壊→その場でデスポーン
・モチを救出→その場でデスポーン
・ウサギをパンチ→画面外に飛んでいく
・ウサギを救出→プレイヤーの背後に回り込む

【確認ファイル】
TowerObjectActionCaller.cs
MochiController.cs
RabbitController.cs