### PR TITLE
α版前DeployGate

### DIFF
--- a/Assets/MyGameAssets/Animation/Player/SpecialArts.anim
+++ b/Assets/MyGameAssets/Animation/Player/SpecialArts.anim
@@ -1883,6 +1883,13 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
+  - time: 3.0833333
+    functionName: TowerFly
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
   - time: 3.95
     functionName: AnimStart
     data: 

--- a/Assets/MyGameAssets/Animation/Timer.controller
+++ b/Assets/MyGameAssets/Animation/Timer.controller
@@ -69,13 +69,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsCountDown
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/MyGameAssets/LibBridge/Scripts/CommonUi/UIResult.cs
+++ b/Assets/MyGameAssets/LibBridge/Scripts/CommonUi/UIResult.cs
@@ -40,6 +40,8 @@ public class UIResult : CmnMonoBehaviour
     /// </summary>
     void OnDisable()
     {
+        // 広告非表示
+        AdManager.Inst.HideResultAd();
         HideBanner();
     }
 

--- a/Assets/MyGameAssets/Scenes/Result.unity
+++ b/Assets/MyGameAssets/Scenes/Result.unity
@@ -170,7 +170,7 @@ PrefabInstance:
     - target: {fileID: 4593146083776088886, guid: e3708c942552346639722a502ab9495b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4593146083776088886, guid: e3708c942552346639722a502ab9495b,
         type: 3}
@@ -247,6 +247,21 @@ PrefabInstance:
       propertyPath: sceneChanger
       value: 
       objectReference: {fileID: 538473432}
+    - target: {fileID: 7640226529962006200, guid: e3708c942552346639722a502ab9495b,
+        type: 3}
+      propertyPath: text
+      value: 
+      objectReference: {fileID: 82080624}
+    - target: {fileID: 7640226529962006200, guid: e3708c942552346639722a502ab9495b,
+        type: 3}
+      propertyPath: buttons
+      value: 
+      objectReference: {fileID: 682178450}
+    - target: {fileID: 7640226529962006200, guid: e3708c942552346639722a502ab9495b,
+        type: 3}
+      propertyPath: playerAnim
+      value: 
+      objectReference: {fileID: 1225688886732000202}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e3708c942552346639722a502ab9495b, type: 3}
 --- !u!224 &82080621 stripped
@@ -279,6 +294,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b2b5cf12f7db477cb2220ac94b4cfd9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &82080624 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 10784615, guid: e3708c942552346639722a502ab9495b,
+    type: 3}
+  m_PrefabInstance: {fileID: 82080620}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &538473427
 GameObject:
   m_ObjectHideFlags: 0
@@ -306,12 +333,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 538473427}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1978891008}
-  m_Father: {fileID: 1429386336}
+  m_Father: {fileID: 682178451}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -438,6 +465,43 @@ MonoBehaviour:
   SceneName: stage1
   FadeType: 1
   FadeColor: {r: 0, g: 0, b: 0, a: 0}
+--- !u!1 &682178450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682178451}
+  m_Layer: 5
+  m_Name: Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &682178451
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682178450}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 538473428}
+  - {fileID: 876045768}
+  m_Father: {fileID: 1429386336}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &704349331
 GameObject:
   m_ObjectHideFlags: 0
@@ -546,10 +610,10 @@ RectTransform:
   m_GameObject: {fileID: 876045767}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 704349332}
-  m_Father: {fileID: 1429386336}
+  m_Father: {fileID: 682178451}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -769,8 +833,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 538473428}
-  - {fileID: 876045768}
+  - {fileID: 682178451}
   - {fileID: 82080621}
   m_Father: {fileID: 1512368740}
   m_RootOrder: 0

--- a/Assets/MyGameAssets/Scenes/stage1.unity
+++ b/Assets/MyGameAssets/Scenes/stage1.unity
@@ -207,6 +207,11 @@ PrefabInstance:
       propertyPath: cameraAnim
       value: 
       objectReference: {fileID: 1790435633}
+    - target: {fileID: 3557069402416809499, guid: ce680b18036564afdbbd65044be67212,
+        type: 3}
+      propertyPath: towerFly
+      value: 
+      objectReference: {fileID: 1069323596}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ce680b18036564afdbbd65044be67212, type: 3}
 --- !u!114 &7310337 stripped
@@ -487,6 +492,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &880184082 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1379747297}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &956974988
 GameObject:
   m_ObjectHideFlags: 0
@@ -636,6 +647,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: TowerObject
       objectReference: {fileID: 0}
+    - target: {fileID: 3001194755703834647, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3001194755703834644, guid: 34e60736b952eee4dba2263ecaaa2597,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -746,6 +762,26 @@ PrefabInstance:
       propertyPath: playerController
       value: 
       objectReference: {fileID: 7310337}
+    - target: {fileID: 532754641122396853, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: timer
+      value: 
+      objectReference: {fileID: 1172636029}
+    - target: {fileID: 5181048982994374361, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: flySpeed
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181048982994374361, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: flyTime
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 5181048982994374361, guid: 34e60736b952eee4dba2263ecaaa2597,
+        type: 3}
+      propertyPath: towerPos
+      value: 
+      objectReference: {fileID: 1069323597}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 34e60736b952eee4dba2263ecaaa2597, type: 3}
 --- !u!4 &1069323590 stripped
@@ -781,6 +817,24 @@ Transform:
 --- !u!4 &1069323595 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 320239592990511528, guid: 34e60736b952eee4dba2263ecaaa2597,
+    type: 3}
+  m_PrefabInstance: {fileID: 1069323589}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1069323596 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5181048982994374361, guid: 34e60736b952eee4dba2263ecaaa2597,
+    type: 3}
+  m_PrefabInstance: {fileID: 1069323589}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f73315bd825259343a9c822b59f7ec3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1069323597 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1212671296861333797, guid: 34e60736b952eee4dba2263ecaaa2597,
     type: 3}
   m_PrefabInstance: {fileID: 1069323589}
   m_PrefabAsset: {fileID: 0}
@@ -847,6 +901,7 @@ GameObject:
   - component: {fileID: 1172636031}
   - component: {fileID: 1172636030}
   - component: {fileID: 1172636029}
+  - component: {fileID: 1172636033}
   m_Layer: 5
   m_Name: Timer
   m_TagString: Untagged
@@ -866,8 +921,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e475f86097f4e433985b8a011280982a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  animator: {fileID: 1172636033}
   timer: {fileID: 1172636030}
-  startTime: 5
+  startTime: 4
   gameTime: 20
   plusSeconds: 5
 --- !u!114 &1172636030
@@ -1006,9 +1062,28 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.000030517578}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!95 &1172636033
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172636028}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: d7c8152270ea44541a20ad53e7c255c2, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1001 &1377599068
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1102,6 +1177,125 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f52d8450b1da39e418d19a6b05d22932, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1379747297
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1429386336}
+    m_Modifications:
+    - target: {fileID: 2280855885174695918, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_Name
+      value: Gallery
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280855885174695919, guid: d431dbda496d2da449943000743e3d8f,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d431dbda496d2da449943000743e3d8f, type: 3}
 --- !u!1 &1429386335
 GameObject:
   m_ObjectHideFlags: 0
@@ -1134,6 +1328,7 @@ RectTransform:
   m_Children:
   - {fileID: 1172636032}
   - {fileID: 1750253935}
+  - {fileID: 880184082}
   m_Father: {fileID: 1512368740}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1212,6 +1407,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1512368740}
   - component: {fileID: 1512368741}
+  - component: {fileID: 1512368742}
   m_Layer: 5
   m_Name: UI Root
   m_TagString: Untagged
@@ -1250,6 +1446,68 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &1512368742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512368739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a35bb9224f51774997ad90c4f687e38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  animationCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 4.656613e-10
+      value: 1
+      inSlope: -0.9494826
+      outSlope: -0.9494826
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.13537176
+    - serializedVersion: 3
+      time: 1.0012228
+      value: -0.000011444092
+      inSlope: -0.7976396
+      outSlope: -0.7976396
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.096066
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  easeType: 22
+  loopStyle: 0
+  delay: 0
+  duration: 1
+  ignoreTimeScale: 1
+  tweenGroup: 0
+  onFinished:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1172636029}
+        m_MethodName: CountStart
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  from: 0
+  to: 0
+  includeChilds: 0
+  overrideOriginalAlpha: 1
 --- !u!1 &1530850428
 GameObject:
   m_ObjectHideFlags: 0
@@ -6153,7 +6411,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_textAlignment: 513
+  m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -6230,7 +6488,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7495dc32652c542118675487634da115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  text: {fileID: 0}
+  text: {fileID: 1647739456}
 --- !u!1 &1750253934
 GameObject:
   m_ObjectHideFlags: 0
@@ -6521,7 +6779,7 @@ PrefabInstance:
     - target: {fileID: 796398417108298435, guid: 737652debfd39470da6112d8670a9a96,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -39.5
       objectReference: {fileID: 0}
     - target: {fileID: 796398417108298435, guid: 737652debfd39470da6112d8670a9a96,
         type: 3}
@@ -6602,6 +6860,761 @@ PrefabInstance:
         type: 3}
       propertyPath: maxTime
       value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298437, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.5000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298437, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4999997
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298437, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298437, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298437, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.037506104
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.45628768
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5396954
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.47555947
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5238069
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.47794804
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.007924558
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298463, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.13270564
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.06433515
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.009019673
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.022232309
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99763995
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.060408242
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00015942754
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298483, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00000007683411
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.07872796
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9950854
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.060022686
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.002033842
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.057085235
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0036344444
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298453, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0839929
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.69441706
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7186758
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.0031080742
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.03578389
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.061874792
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.031786688
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298475, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.08180023
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.062235072
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.010037988
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.005536581
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99799573
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.20472738
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00018903658
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298485, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000000013154928
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.8203581
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04924142
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5675942
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.04924143
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.03969966
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0044264207
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298445, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.041270692
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.3398763
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.065822445
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.11955038
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9305156
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.061172437
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000000044819877
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298439, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000000005587934
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.46205044
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.2008632
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.36304468
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.78381234
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.16467142
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000000057741975
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298459, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00000067055197
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.630204
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.18353117
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.73176193
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.18353118
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.033792812
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.023334514
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298467, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.03645078
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.036576457
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.00006957166
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00079344213
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9993305
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.3819499
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000000046449703
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298443, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00000008288769
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.02409774
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.027836854
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.32778206
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9440357
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.48993617
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000000022992024
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298447, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0013362746
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.27965468
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.06344418
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.1633503
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.94397295
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.2659974
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0000002011656
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298449, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0000011026856
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.67112106
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09761795
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.09393262
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.72886485
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.23778865
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.000000013504172
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298451, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00028179202
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.23545307
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.00009129752
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.048184108
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.97069055
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.0058186622
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298461, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00000001990702
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.07930994
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.587415
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.23023531
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7717806
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.16467206
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000013411038
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298481, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00000066310133
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.0054896567
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.009877701
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.97444755
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.22433081
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.3819498
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000041723246
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298465, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.000000050291426
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.016777506
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.00014269628
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.24426016
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.96956456
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.48993835
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298469, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00032330566
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.22903275
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.023141565
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.66610336
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70944685
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.2659987
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000013411042
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298471, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000000059604606
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.78332984
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.11923008
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.15001638
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.591332
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.23779209
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000002980232
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298473, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00025040566
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.00000050025585
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.00000043027038
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.94038224
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.34011966
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.13111308
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.16845158
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298455, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00000001559965
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.00000079345335
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.0000006790491
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.9986832
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.05130239
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.13100523
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.16859798
+      objectReference: {fileID: 0}
+    - target: {fileID: 796398417108298477, guid: 737652debfd39470da6112d8670a9a96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.000000031330266
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 737652debfd39470da6112d8670a9a96, type: 3}

--- a/Assets/MyGameAssets/Script/Ad/AdMob/AdManager.cs
+++ b/Assets/MyGameAssets/Script/Ad/AdMob/AdManager.cs
@@ -57,6 +57,11 @@ public class AdManager : SingletonMonoBehaviour<AdManager>
     [SerializeField]
     AdVideoRecommender adVideoRecommender = default;                  // 動画リワード広告クラス
 
+    [SerializeField]
+    Animator adVideoRecommenderAnim = default;                        //
+    [SerializeField]
+    Animator OwnCompAdCanvasAnim = default;                           //
+
     int showCount = 0;                                                // インタースティシャル用表示回数
     const string ShowCountKey = "ShowCount";                          // 表示回数データのキー
 
@@ -180,6 +185,23 @@ public class AdManager : SingletonMonoBehaviour<AdManager>
         else
         {
             nendInterstitial.Show();
+        }
+    }
+
+    /// <summary>
+    /// リサルト広告の非表示
+    /// </summary>
+    public void HideResultAd()
+    {
+        // 5回毎の動画リワードを非表示
+        if (showCount % RewardCount == 0)
+        {
+            adVideoRecommenderAnim.SetTrigger("Small");
+        }
+        // それ以外
+        else
+        {
+            OwnCompAdCanvasAnim.SetTrigger("FadeOut");
         }
     }
 

--- a/Assets/MyGameAssets/Script/Player/MainPlayerAnimator.cs
+++ b/Assets/MyGameAssets/Script/Player/MainPlayerAnimator.cs
@@ -30,14 +30,8 @@ public class MainPlayerAnimator : SingletonMonoBehaviour<MainPlayerAnimator>
     [SerializeField]
     Animator cameraAnim = default;          // カメラのアニメーター
 
-    /// <summary>
-    /// 起動処理
-    /// </summary>
-    void OnEnable()
-    {
-        // 開始時にメインの待機モーションへ移動させる
-        playerAnim.SetTrigger("Main");
-    }
+    [SerializeField]
+    TowerFlyController towerFly = default;  // タワーを吹っ飛ばすクラス
 
     /// <summary>
     ///  アニメーション再生
@@ -97,5 +91,13 @@ public class MainPlayerAnimator : SingletonMonoBehaviour<MainPlayerAnimator>
     public void StartSpecialArtsCameraAnim()
     {
         cameraAnim.SetTrigger("SpecialArts");
+    }
+
+    /// <summary>
+    /// タワーを吹っ飛ばすアニメーションイベント用関数
+    /// </summary>
+    public void TowerFly()
+    {
+        towerFly.enabled = true;
     }
 }

--- a/Assets/MyGameAssets/Script/ScoreCountUpper.cs
+++ b/Assets/MyGameAssets/Script/ScoreCountUpper.cs
@@ -8,15 +8,21 @@ using TMPro;
 /// </summary>
 public class ScoreCountUpper : MonoBehaviour
 {
-    int nowCount = 0;                   // 現在のカウント
-    bool isEnd = false;                 // 終了フラグ 
-    bool isStart = false;               // 開始フラグ
+    float nowCount = 0;                                   // 現在のカウント
+    public bool IsEnd { get; private set; } = false;    // 終了フラグ 
+    bool isStart = false;                               // 開始フラグ
 
     [SerializeField]
-    float waitTime = 5.0f;              // カウントにかかるの時間
+    float waitTime = 5.0f;                              // カウントにかかるの時間
 
     [SerializeField]
-    TextMeshProUGUI text = default;     // テキスト
+    TextMeshProUGUI text = default;                     // テキスト
+
+    [SerializeField]
+    GameObject buttons = default;                       // ボタンのオブジェクト
+
+    [SerializeField]
+    ResultPlayerAnimator playerAnim = default;          // プレイヤーのアニメーション
 
     /// <summary>
     /// 起動処理
@@ -32,19 +38,21 @@ public class ScoreCountUpper : MonoBehaviour
     void Update()
     {
         // カウント開始されたらスコアをカウントアップ
-        if (isStart && !isEnd)
+        if (isStart && !IsEnd)
         {
-            nowCount += (int)(ScoreManager.Inst.NowBreakNum * (Time.deltaTime / waitTime));
-
+            nowCount += (ScoreManager.Inst.NowBreakNum * (Time.deltaTime / waitTime));
+            Debug.Log(nowCount);
             if (ScoreManager.Inst.NowBreakNum <= nowCount)
             {
                 // カウントダウン終了
-                isEnd = true;
+                IsEnd = true;
+                buttons.SetActive(true);
+                playerAnim.AnimStart((int)ResultPlayerAnimator.AnimKind.ScoreResult);
             }
         }
 
         // テキストにセット
-        text.text = nowCount.ToString();
+        text.text = ((int)nowCount).ToString();
     }
 
     /// <summary>
@@ -54,7 +62,8 @@ public class ScoreCountUpper : MonoBehaviour
     {
         // リセット
         nowCount = 0;
-        isEnd = false;
+        IsEnd = false;
+        buttons.SetActive(false);
         ScoreManager.Inst.Reset();
     }
 }

--- a/Assets/MyGameAssets/Script/ScoreCountUpper.cs
+++ b/Assets/MyGameAssets/Script/ScoreCountUpper.cs
@@ -41,7 +41,8 @@ public class ScoreCountUpper : MonoBehaviour
         if (isStart && !IsEnd)
         {
             nowCount += (ScoreManager.Inst.NowBreakNum * (Time.deltaTime / waitTime));
-            Debug.Log(nowCount);
+
+            // カウントし終わったら
             if (ScoreManager.Inst.NowBreakNum <= nowCount)
             {
                 // カウントダウン終了

--- a/Assets/MyGameAssets/Script/Timer.cs
+++ b/Assets/MyGameAssets/Script/Timer.cs
@@ -32,14 +32,19 @@ public class Timer : MonoBehaviour
     }
 
     /// <summary>
-    /// カウント開始処理
+    /// カウント開始処理呼び出し関数
     /// NOTE: m.tanaka メインのフェードアウトが終わったら呼ばれるようになってます
+    ///       k.oishi  UTweenAlphaの呼びたしが一度しかされないためとりあえずOnEnableで呼ぶようにしました
     /// </summary>
     public void CountStart()
     {
         // すぐカウントダウンが始まってしまうため少し遅らせる
         //Invoke("_CountStart", 0.5f);
     }
+
+    /// <summary>
+    /// カウント開始処理
+    /// </summary>
     void _CountStart()
     {
         // 処理を許可

--- a/Assets/MyGameAssets/Script/Timer.cs
+++ b/Assets/MyGameAssets/Script/Timer.cs
@@ -25,6 +25,12 @@ public class Timer : MonoBehaviour
     public bool IsTimeup { get; private set; } = false;    // タイムアップフラグ
     public bool IsStart  { get; private set; } = false;    // ゲームスタートまでのカウントダウンフラグ
 
+     void OnEnable()
+    {
+        // すぐカウントダウンが始まってしまうため少し遅らせる
+        Invoke("_CountStart", 0.5f);
+    }
+
     /// <summary>
     /// カウント開始処理
     /// NOTE: m.tanaka メインのフェードアウトが終わったら呼ばれるようになってます
@@ -32,7 +38,7 @@ public class Timer : MonoBehaviour
     public void CountStart()
     {
         // すぐカウントダウンが始まってしまうため少し遅らせる
-        Invoke("_CountStart", 0.5f);
+        //Invoke("_CountStart", 0.5f);
     }
     void _CountStart()
     {
@@ -102,10 +108,18 @@ public class Timer : MonoBehaviour
     }
 
     /// <summary>
+    /// 停止処理
+    /// </summary>
+    void OnDisable()
+    {
+        IsTimeup = false;
+    }
+
+    /// <summary>
     /// うさぎを助けた時のタイムプラス
     /// </summary>
     public void TimePlus()
     {
-        gameTime += plusSeconds;
+        countTime += plusSeconds;
     }
 }

--- a/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
@@ -17,16 +17,16 @@ public class TowerFlyController : MonoBehaviour
     [SerializeField]
     int flyTime = 0;
 
-    // 時間カウント
-    int flyTimeCount = 0;
+    // 初期位置
+    Vector3 initPos = Vector3.zero;
 
     /// <summary>
-    /// 開始
+    /// 開始処理
     /// </summary>
-    void OnEnable()
+    void Start()
     {
-        // カウントを初期化
-        flyTimeCount = 0;
+        // 初期位置を設定
+        initPos = stackedObjectParent.transform.position;
     }
 
     /// <summary>
@@ -36,11 +36,18 @@ public class TowerFlyController : MonoBehaviour
     {
         // タワーを上に飛ばす
         stackedObjectParent.Translate(0, flySpeed, 0);
+    }
 
-        // カウントが指定時間を超えたら終了
-        if (flyTimeCount > flyTime)
-        {
-            enabled = false;
-        }
+    /// <summary>
+    /// 停止処理
+    /// </summary>
+    void OnDisable()
+    {
+        // ポジションをリセットして非アクティブにする
+        stackedObjectParent.localPosition = initPos;
+
+        // NOTE: このスクリプトを持っている親オブジェクト自体が非アクティブの状態になっても、
+        //       このスクリプト自体が非アクティブになるわけではないのでenabled = false;をつけました。
+        enabled = false;
     }
 }

--- a/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
@@ -10,7 +10,6 @@ public class TowerFlyController : MonoBehaviour
     // 積まれているオブジェクトの親
     [SerializeField]
     Transform stackedObjectParent = default;
-
     // 飛ぶスピード
     [SerializeField]
     float flySpeed = 0;
@@ -21,6 +20,8 @@ public class TowerFlyController : MonoBehaviour
 
     // 時間カウント
     int flyTimeCount = 0;
+
+    Vector3 initPos = new Vector3(0, -5, 0);
 
     /// <summary>
     /// 開始
@@ -38,11 +39,16 @@ public class TowerFlyController : MonoBehaviour
     {
         // タワーを上に飛ばす
         stackedObjectParent.Translate(0, flySpeed, 0);
+    }
 
-        // カウントが指定時間を超えたら終了
-        if (flyTimeCount > flyTime)
-        {
-            enabled = false;
-        }
+    /// <summary>
+    /// 停止処理
+    /// </summary>
+    void OnDisable()
+    {
+        flyTimeCount = 0;
+        stackedObjectParent.localPosition = initPos;
+        enabled = false;
+        Debug.Log("aaaaaaaaaaaaaaaaaaa");
     }
 }

--- a/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
@@ -13,15 +13,12 @@ public class TowerFlyController : MonoBehaviour
     // 飛ぶスピード
     [SerializeField]
     float flySpeed = 0;
-
     // 飛ぶ時間
     [SerializeField]
     int flyTime = 0;
 
     // 時間カウント
     int flyTimeCount = 0;
-
-    Vector3 initPos = new Vector3(0, -5, 0);
 
     /// <summary>
     /// 開始
@@ -37,18 +34,10 @@ public class TowerFlyController : MonoBehaviour
     /// </summary>
     void Update()
     {
-        // タワーを上に飛ばす
-        stackedObjectParent.Translate(0, flySpeed, 0);
-    }
-
-    /// <summary>
-    /// 停止処理
-    /// </summary>
-    void OnDisable()
-    {
-        flyTimeCount = 0;
-        stackedObjectParent.localPosition = initPos;
-        enabled = false;
-        Debug.Log("aaaaaaaaaaaaaaaaaaa");
+        // カウントが指定時間を超えたら終了
+        if (flyTimeCount > flyTime)
+        {
+            enabled = false;
+        }
     }
 }

--- a/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerFlyController.cs
@@ -34,6 +34,9 @@ public class TowerFlyController : MonoBehaviour
     /// </summary>
     void Update()
     {
+        // タワーを上に飛ばす
+        stackedObjectParent.Translate(0, flySpeed, 0);
+
         // カウントが指定時間を超えたら終了
         if (flyTimeCount > flyTime)
         {

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectActionCaller.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectActionCaller.cs
@@ -23,6 +23,10 @@ public class TowerObjectActionCaller : MonoBehaviour
     [SerializeField]
     Transform stackedObjectParent = default;
 
+    // タイマークラス
+    [SerializeField]
+    Timer timer = default;
+
     /// <summary>
     /// 更新
     /// </summary>
@@ -52,9 +56,19 @@ public class TowerObjectActionCaller : MonoBehaviour
             {
                 // パンチされたときのコールバック
                 objCtrl.OnPlayerPunched();
+                // 餅だったらスコアプラス
+                if (objCtrl.tag == TagName.Mochi)
+                {
+                    ScoreManager.Inst.UpdateGetNum();
+                }
             }
             else if (rescue)
             {
+                // ウサギだったらタイムプラス
+                if (objCtrl.tag == TagName.Rabbit)
+                {
+                    timer.TimePlus();
+                }
                 // 救出されたときのコールバック
                 objCtrl.OnPlayerRescued();
             }
@@ -62,11 +76,11 @@ public class TowerObjectActionCaller : MonoBehaviour
 #endif
 
         // プレイヤーのそれぞれのアクションのフラグを取得する
-        bool isPaunched = playerController.GetIsPunch();
+        bool isPunched = playerController.GetIsPunch();
         bool isRescued = playerController.GetIsRescue();
 
         // プレイヤーが何らかのアクションを起こしたときのみ、以下の処理を行う
-        if (!isPaunched && !isRescued)
+        if (!isPunched && !isRescued)
         {
             return;
         }
@@ -79,14 +93,24 @@ public class TowerObjectActionCaller : MonoBehaviour
         ObjectControllerBase objectController = objectControllerList.ObjectControllers[underObject.gameObject.name];
 
         // プレイヤーからパンチされたとき
-        if (punch)
+        if (isPunched)
         {
+            // 餅だったらスコアプラス
+            if (underObject.tag == TagName.Mochi)
+            {
+                ScoreManager.Inst.UpdateGetNum();
+            }
             // パンチされたときのコールバック
             objectController.OnPlayerPunched();
         }
         // プレイヤーから救出されたとき
-        else if (rescue)
+        else if (isRescued)
         {
+            // ウサギだったらタイムプラス
+            if (underObject.tag == TagName.Rabbit)
+            {
+                timer.TimePlus();
+            }
             // 救出されたときのコールバック
             objectController.OnPlayerRescued();
         }

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectFallController.cs
@@ -34,19 +34,22 @@ public class TowerObjectFallController : MonoBehaviour
     /// </summary>
     void Update()
     {
-        // 前フレームのオブジェクト数と比較して、タワーオブジェクトの数が変動したかチェック
-        if (stackedObjectParent.childCount != prevStackedObjectNum)
+        if (!isFalling)
         {
-            // オブジェクトのスポーン間隔の幅を落下移動距離として取得
-            fallDistance = towerObjectSpawner.SpawnHeightInterval;
+            // 前フレームのオブジェクト数と比較して、タワーオブジェクトの数が変動したかチェック
+            if (stackedObjectParent.childCount != prevStackedObjectNum)
+            {
+                // オブジェクトのスポーン間隔の幅を落下移動距離として取得
+                fallDistance = towerObjectSpawner.SpawnHeightInterval;
 
-            // 親オブジェクトの移動先の位置を算出
-            fallEndPosition = new Vector3(stackedObjectParent.position.x,
-                                          stackedObjectParent.position.y - fallDistance,
-                                          stackedObjectParent.position.z);
+                // 親オブジェクトの移動先の位置を算出
+                fallEndPosition = new Vector3(stackedObjectParent.position.x,
+                                              stackedObjectParent.position.y - fallDistance,
+                                              stackedObjectParent.position.z);
 
-            // 落下フラグをオンにする
-            isFalling = true;
+                // 落下フラグをオンにする
+                isFalling = true;
+            }
         }
 
         // フラグがオンであれば落下処理を行う

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -106,7 +106,7 @@ public class TowerObjectSpawner : MonoBehaviour
                 spawnedObject.gameObject.SetActive(true);
 
                 // 前回スポーンしたオブジェクトをウサギとして登録する
-                prevSpawnObjectType = TagName.Rabbit; ;
+                prevSpawnObjectType = TagName.Rabbit;
             }
 
             // カウンター
@@ -117,8 +117,6 @@ public class TowerObjectSpawner : MonoBehaviour
     /// <summary>
     /// 指定したオブジェクトを消す
     /// </summary>
-    /// <param name="objectType">消すオブジェクトの種類</param>
-    /// <param name="instance">消すオブジェクトのインスタンス</param>
     public void Despawn(Transform spawnedObject)
     {
         // モチだった場合


### PR DESCRIPTION
α版前時点のDeployGate版です。
・AdManager.cs
タイトル、リトライすると広告が残ってしまっていたので非表示関数追加
・MainPlayerAnimator.cs
タワーを大技で吹き飛ばすためのアニメーションイベント用関数追加
・UIResult.cs
非表示関数をOnDisableに追加
・ScoreCountUpper.cs
スコア発表時のプレイヤーアニメーション追加と、発表する前からタイトル、リトライボタンが押せるようになっていたので修正
・ScoreCountUpper.cs
UTweenAlphaが関数を一度しか呼ばれなかったため、ひとまずOnEnableに
・TowerObjectActionCaller.cs
フラグが正しく設定されていなかったため修正
・TowerObjectFallController.cs
落下処理が２回行われていたためフラグを追加して修正
・TowerFlyController
タワーの吹っ飛ばしクラス