### PR TITLE
モチのみをスポーンさせる処理を追加

### DIFF
--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
@@ -15,6 +15,10 @@ public class TowerObjectSpawnController : MonoBehaviour
     // スポーンさせる数
     [SerializeField] int spawnNum = 0;
 
+    // フィーバータイムコントローラー
+    [SerializeField]
+    FeverTimeController feverTimeController = default;
+
     /// <summary>
     /// 更新
     /// </summary>
@@ -24,8 +28,18 @@ public class TowerObjectSpawnController : MonoBehaviour
         // 新たにオブジェクトを生成する
         if (towerObjectSpawner.StackedObjects.Count < spawnNum)
         {
-            // オブジェクトをスポーンする
-            towerObjectSpawner.Spawn(spawnNum);
+            // フィーバータイムはモチのみをスポーンする
+            if (feverTimeController.IsFever)
+            {
+                // オブジェクトをスポーンする
+                towerObjectSpawner.SpawnMochiOnly(spawnNum);
+            }
+            // 通常通り、抽選結果をもとにスポーンする
+            else
+            {
+                // オブジェクトをスポーンする
+                towerObjectSpawner.Spawn(spawnNum);
+            }
         }
     }
 }

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -109,6 +109,38 @@ public class TowerObjectSpawner : MonoBehaviour
     }
 
     /// <summary>
+    /// モチのみ生成
+    /// </summary>
+    /// <param name="spawnNum">生成する数</param>
+    public void SpawnMochiOnly(int spawnNum)
+    {
+        // スポーンしたオブジェクト
+        Transform spawnedObject;
+        // 基準のスポーン位置を取得
+        Vector3 baseSpawnPos = GetBaseSpawnPos();
+        // 指定の数だけ繰り返し抽選を行い、スポーンしていく
+        for (int spawnCount = 0; spawnCount < spawnNum;)
+        {
+            // スポーン位置の計算
+            Vector3 spawnPos = new Vector3(baseSpawnPos.x, baseSpawnPos.y + (spawnHeightInterval * spawnCount), baseSpawnPos.z);
+
+            // スポーンプールからモチのオブジェクトをスポーンさせる
+            spawnedObject = mochiSpawnPool.Spawn(mochiSkinType.ToString(), spawnPos, Quaternion.identity);
+            // 前回スポーンしたオブジェクトをモチとして登録する
+            prevSpawnObjectType = TagName.Mochi;
+
+            // 生成したオブジェクトをオンにする
+            // NOTE : 何故か自動でオンになってくれないときがあるため
+            spawnedObject.gameObject.SetActive(true);
+            // 生成したオブジェクトをリストに追加
+            stackedObjects.Add(spawnedObject.transform);
+
+            // カウンター
+            spawnCount++;
+        }
+    }
+
+    /// <summary>
     /// 指定したオブジェクトを消す
     /// </summary>
     public void Despawn(Transform spawnedObject)


### PR DESCRIPTION
フィーバータイム用にモチのみをスポーンさせる処理を作成して、スポーンの制御クラスのほうでそれを制御するようにした。
フィーバータイムの発動タイミングを制御する処理は未実装。

【確認ファイル】
TowerObjectSpawner.cs
TowerObjectSpawnController.cs