### PR TITLE
救出されたことのないウサギだけで抽選を行う処理を作成

### DIFF
--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlackRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlackRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: BlackRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 1
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlueRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlueRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: BlueRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 10
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BossRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BossRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: BossRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 20
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ChocosoftRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ChocosoftRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: ChocosoftRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 18
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/DiamondRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/DiamondRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: DiamondRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 19
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GhostRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GhostRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: GhostRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 7
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GreenRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GreenRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: GreenRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 12
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JoysonRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JoysonRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: JoysonRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 5
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JusaburoRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JusaburoRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: JusaburoRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 21
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/KagamimochiRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/KagamimochiRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: KagamimochiRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 16
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/LehmanRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/LehmanRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: LehmanRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 2
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/MaidRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/MaidRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: MaidRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 23
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/MechaRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/MechaRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: MechaRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 14
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/NormalRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/NormalRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: NormalRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 0
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/OgisanRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/OgisanRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: OgisanRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 22
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/PinkRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/PinkRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: PinkRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 13
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RabbitMan.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RabbitMan.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: RabbitMan
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 24
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RedRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RedRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: RedRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 9
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SpaceRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SpaceRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: SpaceRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 8
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SumouRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SumouRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: SumouRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 3
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WarriorRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WarriorRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: WarriorRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 17
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WoodRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WoodRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: WoodRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 4
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/YellowRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/YellowRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: YellowRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 11
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZariganRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZariganRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: ZariganRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 15
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZombieRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZombieRabbit.asset
@@ -12,6 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f34d0070afd4694a9ab46d1b6377013, type: 3}
   m_Name: ZombieRabbit
   m_EditorClassIdentifier: 
-  rabbitObject: {fileID: 0}
   number: 6
-  spawnRate: 0
+  spawnRate: 100

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
@@ -38,7 +38,7 @@ public class TowerObjectSpawnController : MonoBehaviour
             else
             {
                 // オブジェクトをスポーンする
-                towerObjectSpawner.Spawn(spawnNum);
+                towerObjectSpawner.Spawn(spawnNum,false);
             }
         }
     }

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -59,11 +59,12 @@ public class TowerObjectSpawner : MonoBehaviour
                                          transform.position.z);
     }
 
-    /// <summary>
-    /// オブジェクトのスポーンを行う
-    /// </summary>
-    /// <param name="spawnNum">スポーンする数</param>
-    public void Spawn(int spawnNum)
+   /// <summary>
+   /// オブジェクトをスポーンする
+   /// </summary>
+   /// <param name="spawnNum">スポーンの数</param>
+   /// <param name="isNotReleasedRabbitOnly">救出されたことのないウサギで抽選を行うかどうか</param>
+    public void Spawn(int spawnNum,bool isNotReleasedRabbitOnly)
     {
         // スポーンしたオブジェクト
         Transform spawnedObject;
@@ -89,8 +90,23 @@ public class TowerObjectSpawner : MonoBehaviour
             {
                 // 連続でウサギがスポーンするのは仕様ではないので、そうなった場合は抽選し直す。
                 if (prevSpawnObjectType == TagName.Rabbit) { continue; }
-                // ウサギの抽選を行う
-                string rabbitId = rabbitLotteryMachine.LotteryRabbit();
+
+                string rarityId = null;
+                string rabbitId = null;
+                // 通常の抽選を行う
+                if (!isNotReleasedRabbitOnly)
+                {
+                    // ウサギのレアリティの抽選を行う
+                    rarityId = rabbitLotteryMachine.LotteryRarity();
+                    // 決定したレアリティに属しているウサギで抽選を行う
+                    rabbitId = rabbitLotteryMachine.LotterySpawnRabbitFromRarity(rarityId);
+                }
+                // 救出されたことのないウサギのみで抽選を行う
+                else
+                {
+                    rabbitId = rabbitLotteryMachine.LotterySpawnRabbitFromNotReleasedRabbits();
+                }
+               
                 // 決定したウサギをスポーンさせる
                 spawnedObject = rabbitSpawnPool.Spawn(rabbitId, spawnPos, Quaternion.identity);
                 // 前回スポーンしたオブジェクトをウサギとして登録する

--- a/Assets/Scripts/TowerDatas/Rabbit/RabbitData.cs
+++ b/Assets/Scripts/TowerDatas/Rabbit/RabbitData.cs
@@ -9,10 +9,6 @@ using VMUnityLib;
 [CreateAssetMenu(menuName = "Data/RabbitData")]
 public sealed class RabbitData : BaseData
 {
-    // ウサギのオブジェクトPrefab
-    [SerializeField]
-    GameObject rabbitObject = default;
-
     // ウサギの番号
     [SerializeField]
     int number = 0;
@@ -22,7 +18,6 @@ public sealed class RabbitData : BaseData
     [Range(0,100)]
     int spawnRate = 0;
 
-    public GameObject RabbitObject { get { return rabbitObject; } }
     public int        Number { get { return number; } }
     public int        SpawnRate    { get { return spawnRate;    } }
 }


### PR DESCRIPTION
引数のフラグで通常どおり抽選を行うか、救出されたことのないウサギで抽選を行うか設定できるようにした。
RabbitDataからモデル用のGameObjectを削除

【確認ファイル】
TowerObjectSpawner.cs
RabbitLotteryMachine.cs
RabbitData.cs