### PR TITLE
フィーバーゲージの不具合修正

### DIFF
--- a/Assets/MyGameAssets/Script/Timer.cs
+++ b/Assets/MyGameAssets/Script/Timer.cs
@@ -122,13 +122,11 @@ public class Timer : MonoBehaviour
 		if (feverTime.IsFever && !isStop)
 		{
 			isStop = true;
-			IsStart = false;
 			timer.enabled = false;
 		}
 		else if (!feverTime.IsFever && isStop)
 		{
 			isStop = false;
-			IsStart = true;
 			timer.enabled = true;
 		}
 	}

--- a/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
+++ b/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
@@ -72,12 +72,16 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
     /// </summary>
     public void AddGauge()
     {
-        // ゲージを加算
-        GaugeCurrentAmount += gaugeIncrement;
-        
-        // スライダーの値を更新
-        // （ゲージの現在と最大の量からスライダーの値を計算）
-        activeGauge.value = (1.0f * (GaugeCurrentAmount / gaugeAmountMax));
+        // フィーバー中は加算を行わない
+        if (!feverTimeController.IsFever)
+        {
+            // ゲージを加算
+            GaugeCurrentAmount += gaugeIncrement;
+
+            // スライダーの値を更新
+            // （ゲージの現在と最大の量からスライダーの値を計算）
+            activeGauge.value = (1.0f * (GaugeCurrentAmount / gaugeAmountMax));
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
フィーバー中にもゲージの加算を行っていたので修正した。
前のプルリク「[救出されたことのないウサギだけで抽選を行う処理を作成](https://github.com/vm-t-yui/mochi-int1/pull/67#issue-310805387)」の確認を先にお願いします。
それがマージされたら、こちらのマージ先をマスターに変更します。

【確認ファイル】
FeverTimeActiveGaugeController.cs