### PR TITLE
吹っ飛ばした分のモチをスコアに加える

### DIFF
--- a/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
@@ -38,6 +38,9 @@ public class TowerBreakController : MonoBehaviour
 
             // 決定した方向をリストに追加
             objectFlyDirections.Add(flyDirection);
+
+            // 吹っ飛ばした分のモチをスコアに加える
+            ScoreManager.Inst.UpdateGetNum();
         }
     }
 


### PR DESCRIPTION
モチマンの最後の大技で吹っ飛んだ分のモチをスコアとして加算するようにした。

【確認ファイル】
TowerBreakController.cs