### PR TITLE
サウンド機能修正

### DIFF
--- a/Assets/MyGameAssets/LibBridge/Scripts/Sound/BgmPlayer.cs
+++ b/Assets/MyGameAssets/LibBridge/Scripts/Sound/BgmPlayer.cs
@@ -19,9 +19,6 @@ namespace VMUnityLib
         bool isResult       = false;                   // リザルトフラグ
         bool isPlayedResult = false;                   // リザルトBGM再生完了フラグ
 
-        [SerializeField]
-        float FadeTime = 2f;                           // フェードイン・フェードアウトにかける時間
-
         /// <summary>
         /// 再生.
         /// </summary>
@@ -89,19 +86,20 @@ namespace VMUnityLib
         /// <summary>
         /// フェードイン
         /// </summary>
-        public void FadeIn()
+        /// <param name="fadeTime">フェードにかかる時間</param>
+        public void FadeIn(float fadeTime)
         {
             // ミュート時は処理を抜ける
             if (GameDataManager.Inst.SettingData.IsBgmMute) { return; }
 
-            StartCoroutine(_FadeIn());
+            StartCoroutine(_FadeIn(fadeTime));
         }
-        IEnumerator _FadeIn()
+        IEnumerator _FadeIn(float fadeTime)
         {
             // 設定データのBGMボリュームに到達するまでループ
             while (spawnedBgm.volume < GameDataManager.Inst.SettingData.BgmVolume)
             {
-                spawnedBgm.volume += GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / FadeTime);
+                spawnedBgm.volume += GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / fadeTime);
 
                 yield return null;
             }
@@ -113,38 +111,43 @@ namespace VMUnityLib
         /// <summary>
         /// フェードアウト
         /// </summary>
-        public void FadeOut()
+        /// <param name="fadeTime">フェードにかかる時間</param>
+        public void FadeOut(float fadeTime)
         {
-            StartCoroutine(_FadeOut());
+            StartCoroutine(_FadeOut(fadeTime));
         }
-        IEnumerator _FadeOut()
+        IEnumerator _FadeOut(float fadeTime)
         {
             // ０に到達するまでループ
             while (spawnedBgm.volume > 0)
             {
-                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / FadeTime);
+                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / fadeTime);
 
                 yield return null;
             }
 
             // ０を下回ってしまっていた時のために代入処理
             spawnedBgm.volume = 0;
+
+            // BGMを停止
+            StopBgm();
         }
 
         /// <summary>
         /// BGM切り替え（フィーバータイム用）
         /// </summary>
         /// <param name="id">切り替えるBGMのID</param>
-        public void ChangeBgm(string id)
+        /// <param name="fadeTime">フェードにかかる時間</param>
+        public void ChangeBgm(string id, float fadeTime)
         {
-            StartCoroutine(_ChangeBgm(id));
+            StartCoroutine(_ChangeBgm(id, fadeTime));
         }
-        IEnumerator _ChangeBgm(string id)
+        IEnumerator _ChangeBgm(string id, float fadeTime)
         {
             // ０に到達するまでループ
             while (spawnedBgm.volume > 0)
             {
-                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / FadeTime);
+                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / fadeTime);
 
                 yield return null;
             }
@@ -159,22 +162,23 @@ namespace VMUnityLib
             PlayBgm(id);
 
             // フェードイン開始
-            FadeIn();
+            FadeIn(fadeTime);
         }
 
         /// <summary>
         /// 元のBGMに戻す（フィーバータイム用）
         /// </summary>
-        public void ReturnBgm()
+        /// <param name="fadeTime">フェードにかかる時間</param>
+        public void ReturnBgm(float fadeTime)
         {
-            StartCoroutine(_ReturnBgm());
+            StartCoroutine(_ReturnBgm(fadeTime));
         }
-        IEnumerator _ReturnBgm()
+        IEnumerator _ReturnBgm(float fadeTime)
         {
             // ０に到達するまでループ
             while (spawnedBgm.volume > 0)
             {
-                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / FadeTime);
+                spawnedBgm.volume -= GameDataManager.Inst.SettingData.BgmVolume * (Time.deltaTime / fadeTime);
 
                 yield return null;
             }
@@ -189,7 +193,7 @@ namespace VMUnityLib
             ReStartBgm();
 
             // フェードイン開始
-            FadeIn();
+            FadeIn(fadeTime);
         }
 
         /// <summary>

--- a/Assets/MyGameAssets/Script/FeverTimeController.cs
+++ b/Assets/MyGameAssets/Script/FeverTimeController.cs
@@ -16,6 +16,10 @@ public class FeverTimeController : MonoBehaviour
     // フィーバータイムの最大値を取得
     public float MaxFeverTimeCount { get { return maxFeverTimeCount; } }
 
+    [SerializeField]
+    float ChangeBgmFadeTime = 0.8f;                       // BGM切り替え時のフェードにかかる時間
+    [SerializeField]
+    float ReturnBgmFadeTime = 1.2f;                       // メインBGMに戻すときのフェードにかかる時間
 
     float currentFeverTimeCount = 0;                      // フィーバータイムの継続時間
 
@@ -34,7 +38,7 @@ public class FeverTimeController : MonoBehaviour
 		mainCameraAnim.AnimStart((int)MainCameraAnimator.AnimKind.FeverIn);
 
         // フィーバータイムのBGMに切り替え
-        BgmPlayer.Inst.ChangeBgm(BgmID.FeverTime);
+        BgmPlayer.Inst.ChangeBgm(BgmID.FeverTime, ChangeBgmFadeTime);
 	}
 
     /// <summary>
@@ -62,6 +66,6 @@ public class FeverTimeController : MonoBehaviour
 		mainCameraAnim.AnimStart((int)MainCameraAnimator.AnimKind.FeverOut);
 
         // 元のBGMに戻す
-        BgmPlayer.Inst.ReturnBgm();
+        BgmPlayer.Inst.ReturnBgm(ReturnBgmFadeTime);
 	}
 }

--- a/Assets/MyGameAssets/Script/Sound/ResultSoundManager.cs
+++ b/Assets/MyGameAssets/Script/Sound/ResultSoundManager.cs
@@ -22,12 +22,32 @@ public class ResultSoundManager : MonoBehaviour
     bool            isPlayed     = false;             // 再生完了フラグ
 
     /// <summary>
-    /// 起動処理
+    /// 初回起動時処理
     /// </summary>
-    void OnEnable()
+    void Awake()
     {
-        isDramRoll = false;
-        isPlayed = false;
+        // 各ボタンにSE再生処理を追加
+        // 決定音再生ボタン
+        foreach (var item in selectSeButtons)
+        {
+            item.onClick.AddListener(() => SePlayer.Inst.PlaySe(SeID.Select));
+            item.onClick.AddListener(() => BgmPlayer.Inst.FadeOut(0.5f));
+        }
+        // ウィンドウオープン音再生ボタン
+        foreach (var item in windowOpenSeButtons)
+        {
+            item.onClick.AddListener(() => SePlayer.Inst.PlaySe(SeID.WindowOpen));
+        }
+        // キャンセル音再生ボタン
+        foreach (var item in cancelSeButtons)
+        {
+            item.onClick.AddListener(() => SePlayer.Inst.PlaySe(SeID.Cancel));
+        }
+        // タップ音再生ボタン
+        foreach (var item in tapSeButtons)
+        {
+            item.onClick.AddListener(() => SePlayer.Inst.PlaySe(SeID.Tap));
+        }
     }
 
     /// <summary>
@@ -64,12 +84,12 @@ public class ResultSoundManager : MonoBehaviour
     void PlaySuitableBgm()
     {
         // うさぎを3回以上殴った時
-        if (GameDataManager.Inst.PlayData.PunchCount > 3)
+        if (GameDataManager.Inst.PlayData.PunchCount >= 3)
         {
             BgmPlayer.Inst.PlayResultBgm(BgmID.Bad);
         }
         // グッドスコア時
-        if (GameDataManager.Inst.PlayData.LastScore >= ScoreManager.NormalScore)
+        else if (GameDataManager.Inst.PlayData.LastScore >= ScoreManager.NormalScore)
         {
             BgmPlayer.Inst.PlayResultBgm(BgmID.GoodScore);
         }
@@ -85,7 +105,9 @@ public class ResultSoundManager : MonoBehaviour
     /// </summary>
     void OnDisable()
     {
-        BgmPlayer.Inst.StopBgm();
+        isDramRoll = false;
+        isPlayed = false;
+
         SePlayer.Inst.StopSeAll();
     }
 }

--- a/Assets/MyGameAssets/Script/Sound/TitleSoundManager.cs
+++ b/Assets/MyGameAssets/Script/Sound/TitleSoundManager.cs
@@ -16,7 +16,7 @@ public class TitleSoundManager : MonoBehaviour
     bool     isPlayed            = false;      // 再生完了フラグ
 
     /// <summary>
-    /// 起動処理
+    /// 初回起動時処理
     /// </summary>
     void Awake()
     {
@@ -25,6 +25,7 @@ public class TitleSoundManager : MonoBehaviour
         foreach (var item in selectSeButtons)
         {
             item.onClick.AddListener(() => SePlayer.Inst.PlaySe(SeID.Select));
+            item.onClick.AddListener(() => BgmPlayer.Inst.FadeOut(1f));
         }
         // ウィンドウオープン音再生ボタン
         foreach (var item in windowOpenSeButtons)
@@ -64,6 +65,6 @@ public class TitleSoundManager : MonoBehaviour
     {
         isPlayed = false;
 
-        BgmPlayer.Inst.StopBgm();
+        SePlayer.Inst.StopSeAll();
     }
 }


### PR DESCRIPTION
BGMのフェード処理にかかる時間を引数でもらうように修正
上記に伴い、フィーバーBGM再生処理を修正
メインゲーム移行時にBGMをフェードアウトするよう修正
リザルトのボタンにSE再生処理を追加

【確認ファイル】
BgmPlayer.cs
FeverTimeContoller.cs
ResultSoundManager.cs
TitleSoundManager.cs