### PR TITLE
入力処理修正、ゲージ非表示

### DIFF
--- a/Assets/MyGameAssets/Animation/Timer/CountDown.anim
+++ b/Assets/MyGameAssets/Animation/Timer/CountDown.anim
@@ -29,7 +29,7 @@ AnimationClip:
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: {x: 1, y: 1, z: 1}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
@@ -55,7 +55,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 0
         inSlope: 0
         outSlope: 0
@@ -83,7 +83,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 0
         inSlope: 0
         outSlope: 0
@@ -133,7 +133,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0.96666664
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -162,7 +162,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 0
         inSlope: 0
         outSlope: 0
@@ -190,7 +190,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 0
         inSlope: 0
         outSlope: 0
@@ -218,7 +218,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 1
         inSlope: 0
         outSlope: 0
@@ -246,7 +246,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 1
         inSlope: 0
         outSlope: 0
@@ -274,7 +274,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1
+        time: 0.96666664
         value: 1
         inSlope: 0
         outSlope: 0

--- a/Assets/MyGameAssets/LibBridge/Scenes/title.unity
+++ b/Assets/MyGameAssets/LibBridge/Scenes/title.unity
@@ -3660,9 +3660,13 @@ PrefabInstance:
       propertyPath: maxTapDisplacementAllowance
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: chargeMode
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: minDragDistance
-      value: 15
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 11400006, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: enableMultiDrag
@@ -3670,11 +3674,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: maxSwipeDuration
       value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: onlyFireWhenLiftCursor
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: enableMultiSwipe
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 11400002, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: m_Enabled
@@ -5952,6 +5964,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: TouchController
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667455, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
         type: 3}

--- a/Assets/MyGameAssets/LibBridge/Scenes/title.unity
+++ b/Assets/MyGameAssets/LibBridge/Scenes/title.unity
@@ -3640,9 +3640,45 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 11400002, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: enableMultiTapFilter
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: multiTapInterval
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: maxMultiTapCount
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: multiTapPosSpacing
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400008, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: maxTapDisplacementAllowance
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400006, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: minDragDistance
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400006, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: enableMultiDrag
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
       propertyPath: m_Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400004, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: maxSwipeDuration
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400002, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}

--- a/Assets/MyGameAssets/LibBridge/Scenes/title.unity
+++ b/Assets/MyGameAssets/LibBridge/Scenes/title.unity
@@ -318,75 +318,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &180162223
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3766140774895095212, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_Name
-      value: TouchEffect
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8771030bf2b18b145b4f822d593378ad, type: 3}
 --- !u!114 &183414595 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 352726561021697083, guid: bd1df978bfc2efd42a396a490575694f,
@@ -3563,7 +3494,7 @@ PrefabInstance:
     - target: {fileID: 8515150765824641470, guid: a3e483b8164f8cf47b4a615e3692a001,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8515150765824641470, guid: a3e483b8164f8cf47b4a615e3692a001,
         type: 3}
@@ -3580,6 +3511,18 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5810027989400906335, guid: a3e483b8164f8cf47b4a615e3692a001,
+        type: 3}
+      propertyPath: _perPrefabPoolOptions.Array.data[19].prefab
+      value: 
+      objectReference: {fileID: 6361824511564568098, guid: c3bb9e3bccc404b51b94741958864e55,
+        type: 3}
+    - target: {fileID: 5810027989400906335, guid: a3e483b8164f8cf47b4a615e3692a001,
+        type: 3}
+      propertyPath: _perPrefabPoolOptions.Array.data[16].prefab
+      value: 
+      objectReference: {fileID: 6361824511564568098, guid: 1fdeeb4a634d542aa879f384bf22b443,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3e483b8164f8cf47b4a615e3692a001, type: 3}
 --- !u!114 &1202071547 stripped
@@ -3642,6 +3585,67 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1225001704
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 100000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_Name
+      value: InputTouches
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400002, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98e68c057badd6848ac979be1fd7eb24, type: 3}
 --- !u!114 &1257925320
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4088,6 +4092,23 @@ PrefabInstance:
       propertyPath: mLocalizeTarget
       value: 
       objectReference: {fileID: 1523869700}
+    - target: {fileID: 1027750784, guid: bd1df978bfc2efd42a396a490575694f, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1865666934937687745, guid: bd1df978bfc2efd42a396a490575694f,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 976309714, guid: bd1df978bfc2efd42a396a490575694f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 976309714, guid: bd1df978bfc2efd42a396a490575694f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd1df978bfc2efd42a396a490575694f, type: 3}
 --- !u!114 &1387121191 stripped
@@ -5884,3 +5905,77 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1001 &2311088934689942484
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2311088934343667455, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_Name
+      value: TouchController
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667449, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311088934343667448, guid: 3b02d6456bed5445fa33ae56c0da0ebf,
+        type: 3}
+      propertyPath: onSwipe.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3b02d6456bed5445fa33ae56c0da0ebf, type: 3}

--- a/Assets/MyGameAssets/Scenes/Result.unity
+++ b/Assets/MyGameAssets/Scenes/Result.unity
@@ -251,6 +251,14 @@ PrefabInstance:
       propertyPath: mochiFall
       value: 
       objectReference: {fileID: 1055376877}
+    - target: {fileID: 321589431, guid: e3708c942552346639722a502ab9495b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 682178450, guid: e3708c942552346639722a502ab9495b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e3708c942552346639722a502ab9495b, type: 3}
 --- !u!224 &82080621 stripped

--- a/Assets/MyGameAssets/Scenes/stage1.unity
+++ b/Assets/MyGameAssets/Scenes/stage1.unity
@@ -338,6 +338,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2959937862547402835, guid: 1d6d75639b191479d866916a3792d35e,
         type: 3}
+      propertyPath: timerGauge
+      value: 
+      objectReference: {fileID: 1149858038699816222}
+    - target: {fileID: 2959937862547402835, guid: 1d6d75639b191479d866916a3792d35e,
+        type: 3}
       propertyPath: feverTimeController
       value: 
       objectReference: {fileID: 333409356}
@@ -346,16 +351,6 @@ PrefabInstance:
       propertyPath: playerTransform
       value: 
       objectReference: {fileID: 582405134}
-    - target: {fileID: 2959937862547402835, guid: 1d6d75639b191479d866916a3792d35e,
-        type: 3}
-      propertyPath: targetCamera
-      value: 
-      objectReference: {fileID: 1790435632}
-    - target: {fileID: 2959937862547402835, guid: 1d6d75639b191479d866916a3792d35e,
-        type: 3}
-      propertyPath: timerGauge
-      value: 
-      objectReference: {fileID: 1149858038699816222}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1d6d75639b191479d866916a3792d35e, type: 3}
 --- !u!1 &333409354
@@ -387,7 +382,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1080134910}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &333409356
 MonoBehaviour:
@@ -2821,53 +2816,6 @@ Transform:
   m_Father: {fileID: 1080134910}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &1046922538
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1046922540}
-  - component: {fileID: 1046922539}
-  m_Layer: 0
-  m_Name: TouchController
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1046922539
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1046922538}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d34089b59592452dbed8cd9d5e46f90, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  player: {fileID: 582405132}
-  timer: {fileID: 1474329050}
-  swipeSensitivity: 7.5
-  maxJudgeCount: 5
---- !u!4 &1046922540
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1046922538}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 12.903267, y: 6.069466, z: 2.246674}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1080134910}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1069323589
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3287,7 +3235,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1080134910}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1123132945
 MonoBehaviour:
@@ -3302,7 +3250,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   timer: {fileID: 1474329050}
-  touch: {fileID: 1046922539}
+  touch: {fileID: 0}
   towerObjectSpawner: {fileID: 1069323592}
   punch:
     m_PersistentCalls:
@@ -4171,6 +4119,26 @@ PrefabInstance:
     - target: {fileID: 741307113, guid: 07ec3564d426a43d380ffd2521cb580d, type: 3}
       propertyPath: m_sharedMaterial
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 741307113, guid: 07ec3564d426a43d380ffd2521cb580d, type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
+    - target: {fileID: 1176046006810580543, guid: 07ec3564d426a43d380ffd2521cb580d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -19.999939
+      objectReference: {fileID: 0}
+    - target: {fileID: 1176046006902389609, guid: 07ec3564d426a43d380ffd2521cb580d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -19.999939
+      objectReference: {fileID: 0}
+    - target: {fileID: 1176046006501270533, guid: 07ec3564d426a43d380ffd2521cb580d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -19.999939
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 07ec3564d426a43d380ffd2521cb580d, type: 3}

--- a/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
+++ b/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
@@ -29,7 +29,7 @@ public class PlayerActionCaller : MonoBehaviour
     void Awake()
     {
         TouchController.Inst.AddEvent((int)TouchController.Touch.Tap, OnPunch);
-        TouchController.Inst.AddEvent((int)TouchController.Touch.Swipe, OnRescue);
+        TouchController.Inst.AddEvent((int)TouchController.Touch.DraggingStart, OnRescue);
     }
 
     /// <summary>

--- a/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
+++ b/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
@@ -24,13 +24,21 @@ public class PlayerActionCaller : MonoBehaviour
     bool isEnd = false;                         // 処理終了フラグ
 
     /// <summary>
+    /// 開始処理
+    /// </summary>
+    void Awake()
+    {
+        TouchController.Inst.AddEvent((int)TouchController.Touch.Tap, OnPunch);
+        TouchController.Inst.AddEvent((int)TouchController.Touch.Swipe, OnRescue);
+    }
+
+    /// <summary>
     /// 起動処理
     /// </summary>
     void OnEnable()
     {
         // フラグリセット
         isEnd = false;
-        touch.Init();
     }
 
     /// <summary>
@@ -39,28 +47,33 @@ public class PlayerActionCaller : MonoBehaviour
     void Update()
     {
         // タイムアップになったら
-        if (timer.IsTimeup)
+        if (timer.IsTimeup && !isEnd)
         {
-            if (!isEnd)
-            {
-                // 大技開始
-                specialArts.Invoke();
-                isEnd = true;
-            }
+            // 大技開始
+            specialArts.Invoke();
+            isEnd = true;
         }
-        // まだ時間が余っていたら
-        else if(timer.IsStart)
+    }
+
+    /// <summary>
+    /// 救助
+    /// </summary>
+    void OnRescue()
+    {
+        if (timer.IsStart && !timer.IsTimeup)
         {
-            // スワイプされたらうさぎ救助開始
-            if (touch.GetIsSwipe() || Input.GetKeyDown(KeyCode.S))
-            {
-                rescue.Invoke();
-            }
-            // タッチされたらパンチ開始
-            else if (touch.GetIsTouch() || Input.GetKeyDown(KeyCode.A))
-            {
-                punch.Invoke();
-            }
+            rescue.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// パンチ
+    /// </summary>
+    void OnPunch()
+    {
+        if (timer.IsStart && !timer.IsTimeup)
+        {
+            punch.Invoke();
         }
     }
 }

--- a/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
+++ b/Assets/MyGameAssets/Script/Player/PlayerActionCaller.cs
@@ -1,11 +1,11 @@
 ﻿using UnityEngine;
 using UnityEngine.Events;
-using System.Linq;
+using VMUnityLib;
 
 /// <summary>
 /// プレイヤーのアクションのコールクラス
 /// </summary>
-public class PlayerActionCaller : MonoBehaviour
+public class PlayerActionCaller : SingletonMonoBehaviour<PlayerActionCaller>
 {
     [SerializeField]
     Timer timer = default;                      // タイマークラス
@@ -22,15 +22,6 @@ public class PlayerActionCaller : MonoBehaviour
     UnityEvent specialArts = new UnityEvent();  // 大技の関数リスト
 
     bool isEnd = false;                         // 処理終了フラグ
-
-    /// <summary>
-    /// 開始処理
-    /// </summary>
-    void Awake()
-    {
-        TouchController.Inst.AddEvent((int)TouchController.Touch.Tap, OnPunch);
-        TouchController.Inst.AddEvent((int)TouchController.Touch.DraggingStart, OnRescue);
-    }
 
     /// <summary>
     /// 起動処理
@@ -58,7 +49,7 @@ public class PlayerActionCaller : MonoBehaviour
     /// <summary>
     /// 救助
     /// </summary>
-    void OnRescue()
+    public void OnRescue()
     {
         if (timer.IsStart && !timer.IsTimeup)
         {
@@ -69,7 +60,7 @@ public class PlayerActionCaller : MonoBehaviour
     /// <summary>
     /// パンチ
     /// </summary>
-    void OnPunch()
+    public void OnPunch()
     {
         if (timer.IsStart && !timer.IsTimeup)
         {

--- a/Assets/MyGameAssets/Script/TouchController.cs
+++ b/Assets/MyGameAssets/Script/TouchController.cs
@@ -15,7 +15,6 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     public enum Touch
     {
         Tap,            // タップ
-        Swipe,          // スワイプ
         DraggingStart,  // ドラック開始
         Dragging,       // ドラック中
         DraggingEnd,    // ドラック後
@@ -25,8 +24,6 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     TouchEffectPlayer touchEffect = default;        // タッチエフェクト
     [SerializeField]
     UnityEvent onTap = new UnityEvent();            // タップの関数リスト
-    [SerializeField]
-    UnityEvent onSwipe = new UnityEvent();          // スワイプの関数リスト
     [SerializeField]
     UnityEvent onDraggingStart = new UnityEvent();  // ドラック開始の関数リスト
     [SerializeField]
@@ -43,7 +40,6 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     {
         // Input.Touchesの初期化
         IT_Gesture.onMultiTapE += OnTap;
-        IT_Gesture.onSwipeStartE += OnSwipeStart;
         IT_Gesture.onDraggingStartE += OnDraggingStart;
         IT_Gesture.onDraggingE += OnDragging;
         IT_Gesture.onDraggingEndE += OnDraggingEnd;
@@ -56,7 +52,6 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     {
         // Input.Touchesの後処理
         IT_Gesture.onMultiTapE -= OnTap;
-        IT_Gesture.onSwipeStartE -= OnSwipeStart;
         IT_Gesture.onDraggingStartE -= OnDraggingStart;
         IT_Gesture.onDraggingE -= OnDragging;
         IT_Gesture.onDraggingEndE -= OnDraggingEnd;
@@ -67,19 +62,9 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     /// </summary>
     void OnTap(Tap tap)
     {
-        //Debug.Log("タップ開始");
+        Debug.Log("タップ開始");
 
         onTap.Invoke();
-    }
-
-    /// <summary>
-    /// スワイプ
-    /// </summary>
-    void OnSwipeStart(SwipeInfo swipe)
-    {
-        Debug.Log("スワイプ開始");
-
-        onSwipe.Invoke();
     }
 
     /// <summary>
@@ -87,7 +72,7 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     /// </summary>
     void OnDraggingStart(DragInfo dragInfo)
     {
-        //Debug.Log("長押し開始");
+        Debug.Log("長押し開始");
 
         onDraggingStart.Invoke();
     }
@@ -97,7 +82,7 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     /// </summary>
     void OnDragging(DragInfo dragInfo)
     {
-        //Debug.Log("長押し中");
+        Debug.Log("長押し中");
 
         onDragging.Invoke();
     }
@@ -107,7 +92,7 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     /// </summary>
     void OnDraggingEnd(DragInfo dragInfo)
     {
-        //Debug.Log("長押し終了");
+        Debug.Log("長押し終了");
 
         onDraggingEnd.Invoke();
     }
@@ -122,7 +107,6 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
         switch(num)
         {
             case (int)Touch.Tap: onTap.AddListener(() => action()); break;
-            case (int)Touch.Swipe: onSwipe.AddListener(() => action()); break;
             case (int)Touch.DraggingStart: onDraggingStart.AddListener(() => action()); break;
             case (int)Touch.Dragging: onDragging.AddListener(() => action()); break;
             case (int)Touch.DraggingEnd: onDraggingEnd.AddListener(() => action()); break;

--- a/Assets/MyGameAssets/Script/TouchController.cs
+++ b/Assets/MyGameAssets/Script/TouchController.cs
@@ -31,9 +31,9 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     [SerializeField]
     UnityEvent onDraggingEnd = new UnityEvent();    // ドラック後の関数リスト
 
-    int dragNum = 0;
-    bool isTap = false;
-    bool isRescue = false;
+    int dragFrame = 0;                              // ドラック処理のフレーム数
+    bool isTap = false;                             // タップの制御フラグ
+    bool isRescue = false;                          // うさぎ救助の制御フラグ
 
     /// <summary>
     /// 起動処理
@@ -105,6 +105,9 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
         Debug.Log("長押し中");
         onDragging.Invoke();
 
+        // ドラックのフレーム数をカウント
+        dragFrame++;
+
         // うさぎ救助
         OnRescue();
     }
@@ -126,9 +129,8 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     ///      ただ場合によっては2フレーム以上になる可能性も０ではないし、コード的にも汚いので今後修正していく予定です。
     void OnRescue()
     {
-        dragNum++;
-
-        if (dragNum >= 2 && !isRescue)
+        // ドラックが２フレーム続いているならうさぎ救助開始
+        if (dragFrame >= 2 && !isRescue)
         {
            PlayerActionCaller.Inst.OnRescue();
            isRescue = true;
@@ -136,11 +138,11 @@ public class TouchController : SingletonMonoBehaviour<TouchController>
     }
 
     /// <summary>
-    /// 初期化
+    /// 各値初期化
     /// </summary>
     void Init()
     {
-        dragNum = 0;
+        dragFrame = 0;
         isRescue = false;
         isTap = false;
     }

--- a/Assets/Prefabs/GageCanvas.prefab
+++ b/Assets/Prefabs/GageCanvas.prefab
@@ -73,7 +73,7 @@ MonoBehaviour:
   m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
@@ -107,11 +107,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8990135610264701006}
     m_Modifications:
-    - target: {fileID: 3398658809193405541, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
-        type: 3}
-      propertyPath: m_Name
-      value: EnduranceTimeGuage
-      objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -170,17 +165,17 @@ PrefabInstance:
     - target: {fileID: 3398658809193405540, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 116
+      value: 213
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -381
+      value: -586
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
         type: 3}
@@ -216,6 +211,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398658809193405541, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e,
+        type: 3}
+      propertyPath: m_Name
+      value: EnduranceTimeGuage
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa43f8ddf73b8f4cb8616e2e0d8e10e, type: 3}
@@ -232,11 +232,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8990135610264701006}
     m_Modifications:
-    - target: {fileID: 3398658809193405541, guid: 55a4f38838b5d8e4189a19425f441ad4,
-        type: 3}
-      propertyPath: m_Name
-      value: FeverTimeActiveGauge
-      objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: 55a4f38838b5d8e4189a19425f441ad4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -295,17 +290,17 @@ PrefabInstance:
     - target: {fileID: 3398658809193405540, guid: 55a4f38838b5d8e4189a19425f441ad4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -93
+      value: -144
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: 55a4f38838b5d8e4189a19425f441ad4,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -126
+      value: -188
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: 55a4f38838b5d8e4189a19425f441ad4,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 3398658809193405540, guid: 55a4f38838b5d8e4189a19425f441ad4,
         type: 3}
@@ -341,6 +336,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398658809193405541, guid: 55a4f38838b5d8e4189a19425f441ad4,
+        type: 3}
+      propertyPath: m_Name
+      value: FeverTimeActiveGauge
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 55a4f38838b5d8e4189a19425f441ad4, type: 3}

--- a/Assets/Prefabs/TouchController.prefab
+++ b/Assets/Prefabs/TouchController.prefab
@@ -1,0 +1,219 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2311088934343667455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2311088934343667449}
+  - component: {fileID: 2311088934343667448}
+  m_Layer: 0
+  m_Name: TouchController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2311088934343667449
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2311088934343667455}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1465541456185141416}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2311088934343667448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2311088934343667455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d34089b59592452dbed8cd9d5e46f90, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  touchEffect: {fileID: 1465541456185141417}
+  onSwipe:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  onTap:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1465541456185141417}
+        m_MethodName: PlayTapEffect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  onDraggingStart:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1465541456185141417}
+        m_MethodName: PlaySwipeEffect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  onDragging:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1465541456185141417}
+        m_MethodName: UpdateSwipePosition
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  onDraggingEnd:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1465541456185141417}
+        m_MethodName: StopEffect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!1001 &2311088934852666747
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2311088934343667449}
+    m_Modifications:
+    - target: {fileID: 3766140774895095212, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_Name
+      value: TouchEffect
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095212, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8771030bf2b18b145b4f822d593378ad, type: 3}
+--- !u!4 &1465541456185141416 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3766140774895095251, guid: 8771030bf2b18b145b4f822d593378ad,
+    type: 3}
+  m_PrefabInstance: {fileID: 2311088934852666747}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1465541456185141417 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3766140774895095250, guid: 8771030bf2b18b145b4f822d593378ad,
+    type: 3}
+  m_PrefabInstance: {fileID: 2311088934852666747}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a442df9f9b652044a824099c8abda3d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/TouchController.prefab.meta
+++ b/Assets/Prefabs/TouchController.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b02d6456bed5445fa33ae56c0da0ebf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Sounds/SE/SelectSE.prefab.meta
+++ b/Assets/Resources/Sounds/SE/SelectSE.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7577d4505ccf55d46b972b75d85d47d8
+guid: c3bb9e3bccc404b51b94741958864e55
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Resources/Sounds/SE/StartSE.prefab.meta
+++ b/Assets/Resources/Sounds/SE/StartSE.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7577d4505ccf55d46b972b75d85d47d8
+guid: 1fdeeb4a634d542aa879f384bf22b443
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
+++ b/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
@@ -42,7 +42,10 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
     void OnEnable()
     {
         // タイマーゲージに表示を切り替えるためフィーバーゲージ非表示に
-        activeGauge.enabled = false;
+        foreach (Transform child in transform)
+        {
+            child.gameObject.SetActive(false);
+        }
     }
 
     /// <summary>
@@ -62,7 +65,11 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
         // ゲージが０になったら、フィーバーゲージを出してフィーバータイム終了
         if (feverTimeController.CurrentFeverTimeCount < 0)
         {
-            activeGauge.enabled = true;
+            foreach (Transform child in transform)
+            {
+                child.gameObject.SetActive(true);
+            }
+
             enabled = false;
         }
     }


### PR DESCRIPTION
Input.Touchesのアセット導入により、入力関係の処理を修正したのと、
フィーバータイム時にゲージを非表示にするのを忘れていたので追記しました。
・TouchEffectPlayer.cs
エフェクト再生を関数、呼び出しをTouchControllerに移動
・PlayerActionCaller.cs
パンチ、救助を関数化、呼び出しをTouchControllerに移動
・TouchController.cs
Input.Touchesのアセットに合わせて処理を修正
・FeverTimeActiveGaugeController.cs
フィーバータイム時にゲージを消すように追記

9/9 18:24 追記
・PlayerActionCaller.cs
シングルトン化し、UnityEvent追加処理をTouchController.csでするように変更
・TouchController.cs
複数の指で同時にタップすると、その本数分だけタップ処理が同時に呼ばれる問題と、
複数の指で素早く連続でタップし続けると、たまにドラックの処理に入ってしまう問題を修正
(ドラックの処理に入ってしまう問題はあとで要修正ですが、とりあえず動きはするので一応あげています。)