### PR TITLE
紅白餅スキン用にマテリアルを交互にセットするクラス作成

### DIFF
--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -6041,6 +6041,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5513838082089453678}
+  - component: {fileID: 394370660966174275}
   - component: {fileID: 7614573003565083709}
   m_Layer: 0
   m_Name: MochiSpawnPool
@@ -6063,6 +6064,22 @@ Transform:
   m_Father: {fileID: 4572601592760403730}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &394370660966174275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9106954157072050465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: daf8a87ecc9dcb04c876a53db800e4f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mochiPool: {fileID: 7614573003565083709}
+  kouhakuMaterials:
+  - {fileID: 2100000, guid: 2c388c8705af22b42b43360acdd3f002, type: 2}
+  - {fileID: 2100000, guid: a71278601edc0e64dadad9ec4b1905ce, type: 2}
 --- !u!114 &7614573003565083709
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6769,6 +6786,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2806529997929001378}
     m_Modifications:
+    - target: {fileID: 8814307937171578455, guid: 75a6d55a05ce76841983f141269d6af4,
+        type: 3}
+      propertyPath: m_Name
+      value: IsobeMochi
+      objectReference: {fileID: 0}
     - target: {fileID: 4225019358296419732, guid: 75a6d55a05ce76841983f141269d6af4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -6823,11 +6845,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8814307937171578455, guid: 75a6d55a05ce76841983f141269d6af4,
-        type: 3}
-      propertyPath: m_Name
-      value: IsobeMochi
       objectReference: {fileID: 0}
     - target: {fileID: 8358510650737920501, guid: 75a6d55a05ce76841983f141269d6af4,
         type: 3}
@@ -7109,6 +7126,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2806529997929001378}
     m_Modifications:
+    - target: {fileID: 8814307937171578455, guid: cd2d8d0994899d84cb1aaab9a3df9d1c,
+        type: 3}
+      propertyPath: m_Name
+      value: KashiwaMochi
+      objectReference: {fileID: 0}
     - target: {fileID: 4225019358296419732, guid: cd2d8d0994899d84cb1aaab9a3df9d1c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7163,11 +7185,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8814307937171578455, guid: cd2d8d0994899d84cb1aaab9a3df9d1c,
-        type: 3}
-      propertyPath: m_Name
-      value: KashiwaMochi
       objectReference: {fileID: 0}
     - target: {fileID: -890642982436201253, guid: cd2d8d0994899d84cb1aaab9a3df9d1c,
         type: 3}
@@ -7700,6 +7717,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: d3e4d152a42ebac40af836b35b71c276,
+        type: 3}
+      propertyPath: m_Name
+      value: MechaRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: d3e4d152a42ebac40af836b35b71c276,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7755,11 +7777,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: d3e4d152a42ebac40af836b35b71c276,
-        type: 3}
-      propertyPath: m_Name
-      value: MechaRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: -8026777861865488098, guid: d3e4d152a42ebac40af836b35b71c276,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -7785,6 +7802,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 5e801d77bd5c5284d8ddadd00bea606e,
+        type: 3}
+      propertyPath: m_Name
+      value: KagamimochiRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 5e801d77bd5c5284d8ddadd00bea606e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7840,11 +7862,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 5e801d77bd5c5284d8ddadd00bea606e,
-        type: 3}
-      propertyPath: m_Name
-      value: KagamimochiRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: -2527922989007971724, guid: 5e801d77bd5c5284d8ddadd00bea606e,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -7870,6 +7887,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: ee0d03722cb12b840bbaa97b5b101695,
+        type: 3}
+      propertyPath: m_Name
+      value: YellowRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: ee0d03722cb12b840bbaa97b5b101695,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7925,11 +7947,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: ee0d03722cb12b840bbaa97b5b101695,
-        type: 3}
-      propertyPath: m_Name
-      value: YellowRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 3623165661914454838, guid: ee0d03722cb12b840bbaa97b5b101695,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -7955,6 +7972,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 2c39a5c5a1f07a24da25431a7d36aa96,
+        type: 3}
+      propertyPath: m_Name
+      value: GhostRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 2c39a5c5a1f07a24da25431a7d36aa96,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8009,11 +8031,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 2c39a5c5a1f07a24da25431a7d36aa96,
-        type: 3}
-      propertyPath: m_Name
-      value: GhostRabbit
       objectReference: {fileID: 0}
     - target: {fileID: 2721130561809044117, guid: 2c39a5c5a1f07a24da25431a7d36aa96,
         type: 3}
@@ -8125,6 +8142,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: f0e0a0de10812c047aa6777d943d6d25,
+        type: 3}
+      propertyPath: m_Name
+      value: JoysonRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: f0e0a0de10812c047aa6777d943d6d25,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8180,11 +8202,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: f0e0a0de10812c047aa6777d943d6d25,
-        type: 3}
-      propertyPath: m_Name
-      value: JoysonRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 7250589384049535217, guid: f0e0a0de10812c047aa6777d943d6d25,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8210,6 +8227,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 5d0fcfdbd6cfe8440a80c3a5db2fe00d,
+        type: 3}
+      propertyPath: m_Name
+      value: NormalRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 5d0fcfdbd6cfe8440a80c3a5db2fe00d,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8265,11 +8287,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 5d0fcfdbd6cfe8440a80c3a5db2fe00d,
-        type: 3}
-      propertyPath: m_Name
-      value: NormalRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: -5872967362033611529, guid: 5d0fcfdbd6cfe8440a80c3a5db2fe00d,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8295,6 +8312,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 40bc81fdb46c5fb4a9020223441f494e,
+        type: 3}
+      propertyPath: m_Name
+      value: GreenRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 40bc81fdb46c5fb4a9020223441f494e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8350,11 +8372,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 40bc81fdb46c5fb4a9020223441f494e,
-        type: 3}
-      propertyPath: m_Name
-      value: GreenRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 2472213026918936503, guid: 40bc81fdb46c5fb4a9020223441f494e,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8380,6 +8397,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: f51c83362665ee04ca54113aa71defed,
+        type: 3}
+      propertyPath: m_Name
+      value: LehmanRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: f51c83362665ee04ca54113aa71defed,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8435,11 +8457,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: f51c83362665ee04ca54113aa71defed,
-        type: 3}
-      propertyPath: m_Name
-      value: LehmanRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: -7699620724635861717, guid: f51c83362665ee04ca54113aa71defed,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8465,6 +8482,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 0821dfb08922255459bc9dd83766af0e,
+        type: 3}
+      propertyPath: m_Name
+      value: WoodRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 0821dfb08922255459bc9dd83766af0e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8520,11 +8542,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 0821dfb08922255459bc9dd83766af0e,
-        type: 3}
-      propertyPath: m_Name
-      value: WoodRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: -844826141513561515, guid: 0821dfb08922255459bc9dd83766af0e,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8550,6 +8567,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2806529997929001378}
     m_Modifications:
+    - target: {fileID: 8814307937171578455, guid: 605081b8384375f4db1e52f6bb8c7e3c,
+        type: 3}
+      propertyPath: m_Name
+      value: KouhakuMochi
+      objectReference: {fileID: 0}
     - target: {fileID: 4225019358296419732, guid: 605081b8384375f4db1e52f6bb8c7e3c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8605,11 +8627,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8814307937171578455, guid: 605081b8384375f4db1e52f6bb8c7e3c,
-        type: 3}
-      propertyPath: m_Name
-      value: KouhakuMochi
-      objectReference: {fileID: 0}
     - target: {fileID: 6306764193405592317, guid: 605081b8384375f4db1e52f6bb8c7e3c,
         type: 3}
       propertyPath: towerObjectSpawner
@@ -8635,6 +8652,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 2b991f3c6d243b84e937b638e3ce55b5,
+        type: 3}
+      propertyPath: m_Name
+      value: DiamondRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 2b991f3c6d243b84e937b638e3ce55b5,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8690,11 +8712,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 2b991f3c6d243b84e937b638e3ce55b5,
-        type: 3}
-      propertyPath: m_Name
-      value: DiamondRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 5722533331596345821, guid: 2b991f3c6d243b84e937b638e3ce55b5,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8720,6 +8737,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: 989f56cd69362a74f8b737d1606b2f7c,
+        type: 3}
+      propertyPath: m_Name
+      value: BlackRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: 989f56cd69362a74f8b737d1606b2f7c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8775,11 +8797,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: 989f56cd69362a74f8b737d1606b2f7c,
-        type: 3}
-      propertyPath: m_Name
-      value: BlackRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 2539726303503381253, guid: 989f56cd69362a74f8b737d1606b2f7c,
         type: 3}
       propertyPath: towerObjectDataManager
@@ -8805,6 +8822,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4537344395100580195}
     m_Modifications:
+    - target: {fileID: 1508582743492943511, guid: faa0553f2f98378438ca90eda40b81a1,
+        type: 3}
+      propertyPath: m_Name
+      value: MaidRabbit
+      objectReference: {fileID: 0}
     - target: {fileID: 8735663774602533659, guid: faa0553f2f98378438ca90eda40b81a1,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8859,11 +8881,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1508582743492943511, guid: faa0553f2f98378438ca90eda40b81a1,
-        type: 3}
-      propertyPath: m_Name
-      value: MaidRabbit
       objectReference: {fileID: 0}
     - target: {fileID: 1100871223246768743, guid: faa0553f2f98378438ca90eda40b81a1,
         type: 3}

--- a/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs
+++ b/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+using PathologicalGames;
+
+/// <summary>
+/// 紅白餅用マテリアルセットクラス
+/// </summary>
+public class KouhakuMaterialSetter : MonoBehaviour
+{
+    [SerializeField]
+    SpawnPool mochiPool = default;           // モチのプール
+
+    [SerializeField]
+    Material[] kouhakuMaterials = default;   // 紅白のマテリアル
+
+    const int CreatedNum = 20;               // 生成しているモチの個数
+
+    /// <summary>
+    /// 開始処理
+    /// </summary>
+    void Start()
+    {
+        int num = 0;
+        foreach (Transform item in mochiPool.transform)
+        {
+            // 名前に"Kouhaku"が含まれている子のみ設定対象にする
+            if (item.ToString().Contains("KouhakuMochi"))
+            {
+                // 「num % 2 == 0 ? 1 : 0」この式により交互にマテリアルを設定
+                item.GetChild(0).GetComponent<Renderer>().material = kouhakuMaterials[num % 2 == 0 ? 1 : 0];
+                num++;
+            }
+
+            // 設定した個数が生成しているモチの個数に達したら処理を抜ける
+            if (num >= CreatedNum)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs
+++ b/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs
@@ -23,7 +23,7 @@ public class KouhakuMaterialSetter : MonoBehaviour
         foreach (Transform item in mochiPool.transform)
         {
             // 名前に"Kouhaku"が含まれている子のみ設定対象にする
-            if (item.ToString().Contains("KouhakuMochi"))
+            if (item.ToString().Contains(SettingData.SkinType.KouhakuMochi.ToString()))
             {
                 // 「num % 2 == 0 ? 1 : 0」この式により交互にマテリアルを設定
                 item.GetChild(0).GetComponent<Renderer>().material = kouhakuMaterials[num % 2 == 0 ? 1 : 0];

--- a/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs.meta
+++ b/Assets/Scripts/TowerDatas/Common/KouhakuMaterialSetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: daf8a87ecc9dcb04c876a53db800e4f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -47,9 +47,9 @@ public class TowerObjectSpawner : MonoBehaviour
     SettingData.SkinType mochiSkinType = SettingData.SkinType.NormalMochi;
 
     /// <summary>
-    /// 開始
+    /// 起動処理
     /// </summary>
-    void Start()
+    void OnEnable()
     {
         // 現在のモチのスキンを取得する
         mochiSkinType = GameDataManager.Inst.SettingData.UseSkin;


### PR DESCRIPTION
初回のみ紅白餅のマテリアルを交互にセットする処理を行うクラスを作成。
一度タイトルに戻ってスキンを変更し、再度プレイする際にスキンの設定がメインゲームに反映されていなかったため処理を修正。

”KouhakuMaterialSetter.cs”に関して、いい名前が思いつかなかったのでこの名前にしてますが、
他によさげなのがある or もうその処理”TowerObjectSpawner.cs”に入れてよくね？って思ったら言ってください。

【確認ファイル】
KouhakuMaterialSetter.cs
TowerObjectSpawner.cs