### PR TITLE
ウサギごとの出現確率を調整

### DIFF
--- a/Assets/Prefabs/NewRabbitPanels/NewRabbitPanelCanvas.prefab
+++ b/Assets/Prefabs/NewRabbitPanels/NewRabbitPanelCanvas.prefab
@@ -518,7 +518,7 @@ RectTransform:
   m_GameObject: {fileID: 4837672860267152193}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1.2, z: 1}
   m_Children: []
   m_Father: {fileID: 9208918303533761098}
   m_RootOrder: 0
@@ -757,7 +757,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &9208918303533761098
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1588,6 +1588,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &6880633610526898801 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1351640978536946434}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &507446038171446843 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -1600,12 +1606,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &6880633610526898801 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1351640978536946434}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1440586496887668579
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2200,12 +2200,6 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
---- !u!224 &7794467057468117026 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 2420288849382011217}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3773355501047104616 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -2218,6 +2212,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7794467057468117026 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 2420288849382011217}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2432302178032192499
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2353,12 +2353,6 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
---- !u!224 &7817211490353244800 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 2432302178032192499}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3749938029304331978 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -2371,6 +2365,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7817211490353244800 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 2432302178032192499}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3155102439448480903
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2441,12 +2441,12 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 300
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -298.3333
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -2466,7 +2466,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -2476,7 +2476,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -2631,6 +2631,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &7052387717013654900 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 3198128427420003335}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4154915802306287934 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -2643,12 +2649,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &7052387717013654900 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 3198128427420003335}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3201322034793089561
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2937,6 +2937,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &9198335729532920478 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 3610224453512332269}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2869119756318095060 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -2949,12 +2955,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &9198335729532920478 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 3610224453512332269}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3768265254371869345
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3090,12 +3090,6 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
---- !u!224 &8788357785820046290 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 3768265254371869345}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2414105854843647896 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -3108,6 +3102,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &8788357785820046290 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 3768265254371869345}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3819059382012338189
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3549,6 +3549,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &8410356483130786743 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 4110241878416679620}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3225054532880357373 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -3561,12 +3567,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8410356483130786743 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 4110241878416679620}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5338009987622675671
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4096,12 +4096,12 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 300
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -486.66666
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4121,7 +4121,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4131,7 +4131,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4221,12 +4221,12 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 300
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -110
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4246,7 +4246,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4256,7 +4256,7 @@ PrefabInstance:
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8143888246300998931, guid: ebe42b4fa8d1c1547a7bce7b8ccaadb3,
         type: 3}
@@ -4564,6 +4564,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &4327411088095991290 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 8192919547726247049}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7239582439188627888 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -4576,12 +4582,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &4327411088095991290 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 8192919547726247049}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8634684846968365619
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4717,6 +4717,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &4209042119716799296 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 8634684846968365619}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7070547141765256970 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -4729,12 +4735,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &4209042119716799296 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 8634684846968365619}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8999248195659469835
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4870,6 +4870,12 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f0d40435df9d354d86c7d2174f6f29a, type: 3}
+--- !u!224 &3557515031224808824 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
+    type: 3}
+  m_PrefabInstance: {fileID: 8999248195659469835}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7577572151561462066 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1570402997336094009, guid: 1f0d40435df9d354d86c7d2174f6f29a,
@@ -4882,12 +4888,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 344445a89b4f74a0e9a0a766903df87e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3557515031224808824 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5601657285448294771, guid: 1f0d40435df9d354d86c7d2174f6f29a,
-    type: 3}
-  m_PrefabInstance: {fileID: 8999248195659469835}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9028632453242546768
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlackRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/BlackRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: BlackRabbit
   m_EditorClassIdentifier: 
   number: 1
-  spawnRate: 80
+  spawnRate: 30

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ChocosoftRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ChocosoftRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: ChocosoftRabbit
   m_EditorClassIdentifier: 
   number: 18
-  spawnRate: 20
+  spawnRate: 10

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/DiamondRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/DiamondRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: DiamondRabbit
   m_EditorClassIdentifier: 
   number: 19
-  spawnRate: 3
+  spawnRate: 5

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GhostRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/GhostRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: GhostRabbit
   m_EditorClassIdentifier: 
   number: 7
-  spawnRate: 2
+  spawnRate: 5

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JoysonRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JoysonRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: JoysonRabbit
   m_EditorClassIdentifier: 
   number: 5
-  spawnRate: 10
+  spawnRate: 15

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JusaburoRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/JusaburoRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: JusaburoRabbit
   m_EditorClassIdentifier: 
   number: 21
-  spawnRate: 10
+  spawnRate: 20

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/LehmanRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/LehmanRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: LehmanRabbit
   m_EditorClassIdentifier: 
   number: 2
-  spawnRate: 60
+  spawnRate: 30

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RabbitMan.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/RabbitMan.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: RabbitMan
   m_EditorClassIdentifier: 
   number: 24
-  spawnRate: 0.1
+  spawnRate: 25

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SpaceRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SpaceRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: SpaceRabbit
   m_EditorClassIdentifier: 
   number: 8
-  spawnRate: 0.5
+  spawnRate: 3

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SumouRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/SumouRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: SumouRabbit
   m_EditorClassIdentifier: 
   number: 3
-  spawnRate: 40
+  spawnRate: 25

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WarriorRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/WarriorRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: WarriorRabbit
   m_EditorClassIdentifier: 
   number: 17
-  spawnRate: 50
+  spawnRate: 30

--- a/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZombieRabbit.asset
+++ b/Assets/Resources/TowerObjectDatas/Rabbit/RabbitDatas/ZombieRabbit.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: ZombieRabbit
   m_EditorClassIdentifier: 
   number: 6
-  spawnRate: 5
+  spawnRate: 10

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawner.cs
@@ -273,6 +273,9 @@ public class TowerObjectSpawner : MonoBehaviour
     /// </summary>
     void OnDisable()
     {
+        // ウサギの図鑑のフラグ関連の終了処理を行う
+        RabbitPictureBookFlagSwitcher.Inst.FinalizeData();
+
         // 積み上げられたオブジェクトを全てデスポーンする
         mochiSpawnPool.DespawnAll();
         rabbitSpawnPool.DespawnAll();

--- a/Assets/Scripts/TowerDatas/Rabbit/RabbitPictureBookFlagSwitcher.cs
+++ b/Assets/Scripts/TowerDatas/Rabbit/RabbitPictureBookFlagSwitcher.cs
@@ -92,9 +92,9 @@ public class RabbitPictureBookFlagSwitcher : Singleton<RabbitPictureBookFlagSwit
     }
 
     /// <summary>
-    /// 終了
+    /// データの終了処理
     /// </summary>
-    void OnDisable()
+    public void FinalizeData()
     {
         // リストに登録されているウサギをもとにフラグを切り替える
         SwitchPictureBookFlag();


### PR DESCRIPTION
一度のプレイで開放できるウサギの数が多いと感じたので、出現確率を調整した。
図鑑のフラグ関連のクラスでシングルトンにした影響で呼ばれていない関数があったので修正した。

【確認ファイル】
TowerObjectSpawner.cs
RabbitPictureBookFlagSwitcher.cs