### PR TITLE
各種細かい調整（詳細はコメントに）

### DIFF
--- a/Assets/Animations/ResultNewRabbitPanel/PanelBlur_Rarity3.anim
+++ b/Assets/Animations/ResultNewRabbitPanel/PanelBlur_Rarity3.anim
@@ -56,7 +56,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.5424528
+        value: 0.5613208
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -65,7 +65,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.5424528
+        value: 0.56078434
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -84,7 +84,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
+        value: 0.99570453
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -93,7 +93,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 1
+        value: 0.99607843
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -112,7 +112,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.9743431
+        value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -121,7 +121,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.9743431
+        value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -309,7 +309,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.5424528
+        value: 0.5613208
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -318,7 +318,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.5424528
+        value: 0.56078434
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -337,7 +337,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
+        value: 0.99570453
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -346,7 +346,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 1
+        value: 0.99607843
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -365,7 +365,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.9743431
+        value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -374,7 +374,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.9743431
+        value: 1
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Animations/ResultNewRabbitPanel/PanelBlur_Rarity4.anim
+++ b/Assets/Animations/ResultNewRabbitPanel/PanelBlur_Rarity4.anim
@@ -84,7 +84,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.63489324
+        value: 0.8662936
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -93,7 +93,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.63529414
+        value: 0.8666667
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -337,7 +337,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.63489324
+        value: 0.8662936
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -346,7 +346,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 2
-        value: 0.63529414
+        value: 0.8666667
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -257,6 +257,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainCameraAnim: {fileID: 0}
+  playerFeverAura: []
   maxFeverTimeCount: 10
   ChangeBgmFadeTime: 0.8
   ReturnBgmFadeTime: 1.2
@@ -12128,7 +12129,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   towerObjectSpawner: {fileID: 6233680672232218299}
   towerObjectRendererList: {fileID: 2822577924656766377}
-  objectFlySpeed: 5
+  objectFlySpeed: 2
 --- !u!1 &7488554835131360139
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
@@ -32,8 +32,8 @@ public class TowerBreakController : MonoBehaviour
         for (int i = 0; i < towerObjectSpawner.StackedObjects.Count; i++)
         {
             // 飛ぶ方向をランダムに生成
-            Vector3 flyDirection = new Vector3(Random.Range(-1.0f, 1.0f),
-                                               Random.Range(-1.0f, 1.0f),
+            Vector3 flyDirection = new Vector3(Random.Range(-1.0f,1.0f),
+                                               Random.Range(1, 1),
                                                Random.Range(-1.0f, 1.0f));
 
             // 決定した方向をリストに追加

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectSpawnController.cs
@@ -32,8 +32,9 @@ public class TowerObjectSpawnController : MonoBehaviour
         // 現在のオブジェクトの数が最低個数を下回っていれば、新たにオブジェクトを生成する
         if (towerObjectSpawner.StackedObjects.Count < objectKeepNum)
         {
-            // フィーバータイムはモチのみをスポーンする
-            if (feverTimeController.IsFever)
+            // 最初のスポーンとフィーバータイム中はモチのみをスポーンする
+            if (towerObjectSpawner.StackedObjects.Count == 0 ||
+                feverTimeController.IsFever)
             {
                 // オブジェクトをスポーンする
                 towerObjectSpawner.SpawnMochiOnly(spawnNum);


### PR DESCRIPTION
新規ウサギ一覧のパネルの発光色を変更した。
タワーのモチが吹っ飛ぶ方向を上方向の範囲に限定して、速度を遅くした。
タワーの一番最初のスポーンはモチのみに変更した。
（一番最初にウサギだと耐久ゲージが少し減ってしまっているため）

【確認ファイル】
TowerObjectController.cs
TowerObjectSpawnController.cs