### PR TITLE
ウサギのパンチによるフィーバーゲージ減少の処理を調整

### DIFF
--- a/Assets/Prefabs/TowerObjectPrefabs/FeverTimeActiveGauge.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/FeverTimeActiveGauge.prefab
@@ -109,6 +109,7 @@ MonoBehaviour:
   playerTransform: {fileID: 0}
   gaugeAmountMax: 100
   gaugeIncrement: 2
+  rabbitPunchDecreaseNum: 15
 --- !u!1 &3398658809896927059
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
+++ b/Assets/Prefabs/TowerObjectPrefabs/TowerObject.prefab
@@ -13319,11 +13319,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7188889747738439892}
     m_Modifications:
-    - target: {fileID: 2824377923100481999, guid: 7e72d20b03298e74485fac0adba95364,
-        type: 3}
-      propertyPath: m_Name
-      value: ichigo
-      objectReference: {fileID: 0}
     - target: {fileID: 1254653926117665756, guid: 7e72d20b03298e74485fac0adba95364,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -13378,6 +13373,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2824377923100481999, guid: 7e72d20b03298e74485fac0adba95364,
+        type: 3}
+      propertyPath: m_Name
+      value: ichigo
       objectReference: {fileID: 0}
     - target: {fileID: 6322324675831730041, guid: 7e72d20b03298e74485fac0adba95364,
         type: 3}
@@ -13479,11 +13479,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8025850714249357282}
     m_Modifications:
-    - target: {fileID: 3796916283438007142, guid: 77757151064d37d4cb1869691051fac4,
-        type: 3}
-      propertyPath: m_Name
-      value: SumouRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 209983522774905205, guid: 77757151064d37d4cb1869691051fac4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -13538,6 +13533,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3796916283438007142, guid: 77757151064d37d4cb1869691051fac4,
+        type: 3}
+      propertyPath: m_Name
+      value: SumouRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 77757151064d37d4cb1869691051fac4, type: 3}
@@ -13779,11 +13779,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5585179842526851218}
     m_Modifications:
-    - target: {fileID: 5174904342670809986, guid: a96f10def4016d04fa37d71c0cb0683a,
-        type: 3}
-      propertyPath: m_Name
-      value: RedRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 8181824240204638609, guid: a96f10def4016d04fa37d71c0cb0683a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -13838,6 +13833,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5174904342670809986, guid: a96f10def4016d04fa37d71c0cb0683a,
+        type: 3}
+      propertyPath: m_Name
+      value: RedRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a96f10def4016d04fa37d71c0cb0683a, type: 3}
@@ -13929,11 +13929,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5787629566245592192}
     m_Modifications:
-    - target: {fileID: 8839121227002337379, guid: b7401697a72775c4784c2477dfb9fc11,
-        type: 3}
-      propertyPath: m_Name
-      value: RabbitMan
-      objectReference: {fileID: 0}
     - target: {fileID: 5544357977047181936, guid: b7401697a72775c4784c2477dfb9fc11,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -13988,6 +13983,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839121227002337379, guid: b7401697a72775c4784c2477dfb9fc11,
+        type: 3}
+      propertyPath: m_Name
+      value: RabbitMan
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b7401697a72775c4784c2477dfb9fc11, type: 3}
@@ -14079,11 +14079,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 6118796572443657116}
     m_Modifications:
-    - target: {fileID: 5522522518274981295, guid: 9925d0596c2ba874bbcd969693af2e71,
-        type: 3}
-      propertyPath: m_Name
-      value: JusaburoRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 8861018223541669820, guid: 9925d0596c2ba874bbcd969693af2e71,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14138,6 +14133,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5522522518274981295, guid: 9925d0596c2ba874bbcd969693af2e71,
+        type: 3}
+      propertyPath: m_Name
+      value: JusaburoRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9925d0596c2ba874bbcd969693af2e71, type: 3}
@@ -14379,11 +14379,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8056694720191411961}
     m_Modifications:
-    - target: {fileID: 6924365570552322280, guid: 2e27ca9a19e3ca445891d6dc68e2195c,
-        type: 3}
-      propertyPath: m_Name
-      value: ZariganRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 6215829589862755067, guid: 2e27ca9a19e3ca445891d6dc68e2195c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14438,6 +14433,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6924365570552322280, guid: 2e27ca9a19e3ca445891d6dc68e2195c,
+        type: 3}
+      propertyPath: m_Name
+      value: ZariganRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2e27ca9a19e3ca445891d6dc68e2195c, type: 3}
@@ -14454,11 +14454,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5523347695896394377}
     m_Modifications:
-    - target: {fileID: 2376318481569864344, guid: 1f4571da574622644911af8cbec65fc6,
-        type: 3}
-      propertyPath: m_Name
-      value: pink_mochi
-      objectReference: {fileID: 0}
     - target: {fileID: 1630646978050009227, guid: 1f4571da574622644911af8cbec65fc6,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14513,6 +14508,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2376318481569864344, guid: 1f4571da574622644911af8cbec65fc6,
+        type: 3}
+      propertyPath: m_Name
+      value: pink_mochi
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f4571da574622644911af8cbec65fc6, type: 3}
@@ -14529,11 +14529,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5654803206685937066}
     m_Modifications:
-    - target: {fileID: 3189139581248225294, guid: 7c03b6e206377f842a74758460545fed,
-        type: 3}
-      propertyPath: m_Name
-      value: BossRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 1880605055517110813, guid: 7c03b6e206377f842a74758460545fed,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14588,6 +14583,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189139581248225294, guid: 7c03b6e206377f842a74758460545fed,
+        type: 3}
+      propertyPath: m_Name
+      value: BossRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c03b6e206377f842a74758460545fed, type: 3}
@@ -14604,11 +14604,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2427163525842685960}
     m_Modifications:
-    - target: {fileID: 7160085806284069042, guid: b9ca692e064c37447bc51f40bc3e1acb,
-        type: 3}
-      propertyPath: m_Name
-      value: GhostRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 6126836964662848161, guid: b9ca692e064c37447bc51f40bc3e1acb,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14663,6 +14658,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160085806284069042, guid: b9ca692e064c37447bc51f40bc3e1acb,
+        type: 3}
+      propertyPath: m_Name
+      value: GhostRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b9ca692e064c37447bc51f40bc3e1acb, type: 3}
@@ -14679,11 +14679,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8999777163140631949}
     m_Modifications:
-    - target: {fileID: 7471219425198045484, guid: 215503cec5413904a90464330813f047,
-        type: 3}
-      propertyPath: m_Name
-      value: OjisanRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 5905419379997903679, guid: 215503cec5413904a90464330813f047,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14738,6 +14733,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471219425198045484, guid: 215503cec5413904a90464330813f047,
+        type: 3}
+      propertyPath: m_Name
+      value: OjisanRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 215503cec5413904a90464330813f047, type: 3}
@@ -14754,11 +14754,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2263017732508765378}
     m_Modifications:
-    - target: {fileID: 8825463881477448877, guid: 707a881b7721a8946a8aafd4ac864f44,
-        type: 3}
-      propertyPath: m_Name
-      value: GreenRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 5485667457464407742, guid: 707a881b7721a8946a8aafd4ac864f44,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14813,6 +14808,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825463881477448877, guid: 707a881b7721a8946a8aafd4ac864f44,
+        type: 3}
+      propertyPath: m_Name
+      value: GreenRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 707a881b7721a8946a8aafd4ac864f44, type: 3}
@@ -14829,11 +14829,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 79928346549545331}
     m_Modifications:
-    - target: {fileID: 7299262390824986296, guid: af94ed17732953c4ca8d279b5198663e,
-        type: 3}
-      propertyPath: m_Name
-      value: DiamondRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 5987370366751413419, guid: af94ed17732953c4ca8d279b5198663e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14888,6 +14883,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7299262390824986296, guid: af94ed17732953c4ca8d279b5198663e,
+        type: 3}
+      propertyPath: m_Name
+      value: DiamondRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: af94ed17732953c4ca8d279b5198663e, type: 3}
@@ -14904,11 +14904,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3965674793387837630}
     m_Modifications:
-    - target: {fileID: 9097388212226106288, guid: 92db42e5b4e567b459eb9f316746226b,
-        type: 3}
-      propertyPath: m_Name
-      value: KagamimochiRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 5195803468690280867, guid: 92db42e5b4e567b459eb9f316746226b,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -14963,6 +14958,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9097388212226106288, guid: 92db42e5b4e567b459eb9f316746226b,
+        type: 3}
+      propertyPath: m_Name
+      value: KagamimochiRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 92db42e5b4e567b459eb9f316746226b, type: 3}
@@ -14979,11 +14979,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 215637706750994604}
     m_Modifications:
-    - target: {fileID: 7101271189287396361, guid: 0f4448242dd36ee4e8e73b41bcf9951f,
-        type: 3}
-      propertyPath: m_Name
-      value: BlackRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 6113514848545805850, guid: 0f4448242dd36ee4e8e73b41bcf9951f,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -15038,6 +15033,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7101271189287396361, guid: 0f4448242dd36ee4e8e73b41bcf9951f,
+        type: 3}
+      propertyPath: m_Name
+      value: BlackRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0f4448242dd36ee4e8e73b41bcf9951f, type: 3}
@@ -15129,11 +15129,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3253729123317107486}
     m_Modifications:
-    - target: {fileID: 2444324919006571484, guid: 674afd33584320247963bcdf50dce962,
-        type: 3}
-      propertyPath: m_Name
-      value: YellowRabbit
-      objectReference: {fileID: 0}
     - target: {fileID: 1707045991163845071, guid: 674afd33584320247963bcdf50dce962,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -15188,6 +15183,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2444324919006571484, guid: 674afd33584320247963bcdf50dce962,
+        type: 3}
+      propertyPath: m_Name
+      value: YellowRabbit
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 674afd33584320247963bcdf50dce962, type: 3}

--- a/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
+++ b/Assets/Scripts/FeverTime/FeverTimeActiveGaugeController.cs
@@ -33,6 +33,10 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
     [SerializeField]
     float gaugeIncrement = 0;
 
+    // ウサギをパンチしたときの減少値
+    [SerializeField]
+    int rabbitPunchDecreaseNum = 0;
+
     // ゲージの現在の量
     public float GaugeCurrentAmount { get; private set; } = 0;
 
@@ -72,6 +76,12 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
 
             enabled = false;
         }
+
+        // ゲージの現在の量が０以下になったら０を代入
+        if (GaugeCurrentAmount < 0)
+        {
+            GaugeCurrentAmount = 0;
+        }
     }
 
     /// <summary>
@@ -89,6 +99,19 @@ public class FeverTimeActiveGaugeController : MonoBehaviour
             // （ゲージの現在と最大の量からスライダーの値を計算）
             activeGauge.value = (1.0f * (GaugeCurrentAmount / gaugeAmountMax));
         }
+    }
+
+    /// <summary>
+    /// ゲージの減少
+    /// </summary>
+    /// <param name="num">減少値</param>
+    public void DecreaseGauge()
+    {
+        GaugeCurrentAmount -= rabbitPunchDecreaseNum;
+
+        // スライダーの値を更新
+        // （ゲージの現在と最大の量からスライダーの値を計算）
+        activeGauge.value = (1.0f * (GaugeCurrentAmount / gaugeAmountMax));
     }
 
     /// <summary>

--- a/Assets/Scripts/TowerDatas/Rabbit/RabbitMoveController.cs
+++ b/Assets/Scripts/TowerDatas/Rabbit/RabbitMoveController.cs
@@ -13,6 +13,10 @@ public class RabbitMoveController : MoveControllerBase
     [SerializeField]
     TowerObjectSpawner towerObjectSpawner = default;
 
+    // フィーバーゲージコントローラー
+    [SerializeField]
+    FeverTimeActiveGaugeController gaugeController = default;
+
     // ウサギのデータ
     RabbitData rabbitData = default;
 
@@ -55,6 +59,8 @@ public class RabbitMoveController : MoveControllerBase
         // ウサギがパンチされた回数をカウントしていく
         GameDataManager.Inst.PlayData.PunchCount++;
         GameDataManager.Inst.PlayData.TotalPunchCount++;
+        // ウサギをパンチしたらフィーバーゲージを減少させる
+        gaugeController.DecreaseGauge();
         // ウサギが吹っ飛ぶアニメーションを再生
         animator.SetTrigger("RabbitFling");
         // ウサギがパンチされた時の効果音再生


### PR DESCRIPTION
ウサギをパンチすることにより、フィーバーゲージを減少させる処理を追加した。
ゲージの現在の量を表す変数が０以下になる可能性があるのを修正した。

【確認ファイル】
FeverTimeActiveGaugeController.cs
RabbitMoveController.cs