### PR TITLE
画面外のウサギが消えていなかったのを修正

### DIFF
--- a/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerBreakController.cs
@@ -92,7 +92,7 @@ public class TowerBreakController : MonoBehaviour
             else
             {
                 // ウサギのレンダラーを取得
-                MeshRenderer[] rabbitRenderer = towerObjectRendererList.MeshRenderers[stackedObject[i].name];
+                SkinnedMeshRenderer[] rabbitRenderer = towerObjectRendererList.MeshRenderers[stackedObject[i].name];
 
                 // タワーのウサギで全てのメッシュが画面の範囲外だったら
                 if (stackedObject[i].tag == TagName.Rabbit && rabbitRenderer.ToList().FindIndex(renderer => renderer.isVisible) == -1)

--- a/Assets/Scripts/TowerDatas/Common/TowerObjectRendererList.cs
+++ b/Assets/Scripts/TowerDatas/Common/TowerObjectRendererList.cs
@@ -16,8 +16,8 @@ public class TowerObjectRendererList : MonoBehaviour
     Transform rabbitSpawnPool = default;
 
     // オブジェクトの制御クラスを管理するDictionary
-    Dictionary<string, MeshRenderer[]> meshRenderers = new Dictionary<string, MeshRenderer[]>();
-    public IReadOnlyDictionary<string, MeshRenderer[]> MeshRenderers { get { return meshRenderers; } }
+    Dictionary<string, SkinnedMeshRenderer[]> meshRenderers = new Dictionary<string, SkinnedMeshRenderer[]>();
+    public IReadOnlyDictionary<string, SkinnedMeshRenderer[]> MeshRenderers { get { return meshRenderers; } }
 
     /// <summary>
     /// 開始
@@ -28,7 +28,7 @@ public class TowerObjectRendererList : MonoBehaviour
         foreach (Transform mochi in mochiSpawnPool)
         {
             // モチにアタッチしているrレンダラーを取得する
-            MeshRenderer[] meshRenderer = mochi.GetChild(0).GetComponentsInChildren<MeshRenderer>();
+            SkinnedMeshRenderer[] meshRenderer = mochi.GetChild(0).GetComponentsInChildren<SkinnedMeshRenderer>();
             // 取得したレンダラーをオブジェクト名とセットで追加
             meshRenderers.Add(mochi.gameObject.name, meshRenderer);
         }
@@ -37,7 +37,7 @@ public class TowerObjectRendererList : MonoBehaviour
         foreach (Transform rabbit in rabbitSpawnPool)
         {
             // ウサギにアタッチしているレンダラーを取得する
-            MeshRenderer[] meshRenderer = rabbit.GetChild(0).GetComponentsInChildren<MeshRenderer>();
+            SkinnedMeshRenderer[] meshRenderer = rabbit.GetChild(0).GetComponentsInChildren<SkinnedMeshRenderer>();
             // 取得したレンダラーをオブジェクト名とセットで追加
             meshRenderers.Add(rabbit.gameObject.name, meshRenderer);
         }


### PR DESCRIPTION
クラスの種類が間違っていたせいで、フィーバー中に画面外のウサギが消えていなったのを修正した。

【確認ファイル】
TowerBreakController.cs
TowerObjectRendererList.cs